### PR TITLE
Fix license classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: GNU Affero General Public License v3 (AGPLv3)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
On PyPI - `MIT License (AGPL-3.0)`

![telegram-cloud-photo-size-2-5332491452250450020-x](https://github.com/user-attachments/assets/b232fd17-1d85-4607-bc55-a9394dde3942)

