### PR TITLE
Remove fetch-depth 0 on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}  # use your PAT here
-          fetch-depth: "0" # pulls all commits (needed for correct last updated dates in Docs)
       - name: Git config
         run: |
           git config --global user.name "UltralyticsAssistant"


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor adjustment to the GitHub Actions workflow configuration.

### 📊 Key Changes
- Removed the `fetch-depth: "0"` configuration from the checkout action in the `publish.yml` workflow file.

### 🎯 Purpose & Impact
- **Simplification**: The modification simplifies the workflow by fetching only the necessary commits, potentially speeding up the action and reducing unnecessary data transfers.
- **Maintenance**: This change makes the workflow easier to maintain by removing an option that may not be required for the current setup.