### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,9 @@ jobs:
     needs: [check, publish]
     if: always() && needs.check.outputs.increment == 'True'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: read
     steps:
       - uses: actions/checkout@v4
       - name: Extract PR Details


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/thop/security/code-scanning/1](https://github.com/ultralytics/thop/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `notify` job. Based on the job's functionality, it only needs `contents: read` to access repository metadata and `statuses: read` to check the status of previous jobs. No write permissions are required. This change will explicitly limit the permissions of the `GITHUB_TOKEN` for the `notify` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved GitHub Actions workflow security by specifying permissions for publishing jobs. 🔒

### 📊 Key Changes
- Added explicit permissions (`contents: read`, `statuses: read`) to the publish job in the GitHub Actions workflow.

### 🎯 Purpose & Impact
- Enhances security by limiting the workflow's access to only what's necessary.
- Follows GitHub best practices, reducing potential risks for users and contributors.
- No impact on end-user functionality—this is a behind-the-scenes improvement for safer project maintenance.