### PR TITLE
Enable trilinear mode calculation in Upsample

### DIFF
--- a/thop/__init__.py
+++ b/thop/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "2.0.14"
+__version__ = "2.0.15"
 
 
 import torch

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -127,7 +127,8 @@ def count_upsample(m, x, y):
         "linear",
         "bilinear",
         "bicubic",
-    ):  # "trilinear"
+        "trilinear",
+    ):
         logging.warning(f"mode {m.mode} is not implemented yet, take it a zero op")
         m.total_ops += 0
     else:


### PR DESCRIPTION
Enable trilinear mode calculation in Upsample

Since issue is not enabled in this repo, I had no way to discuss this change with any of the maintainers but to submit a pull request directly.

I have read the CLA Document and I sign the CLA
