### PR TITLE
Ruff `RUF` refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 # 🚀 THOP: PyTorch-OpCounter
 
-
-
 Welcome to the [THOP](https://github.com/ultralytics/thop) repository, your comprehensive solution for profiling [PyTorch](https://pytorch.org/) models by computing the number of Multiply-Accumulate Operations (MACs) and parameters. Developed by Ultralytics, this tool is essential for [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) practitioners aiming to evaluate model efficiency and performance, crucial aspects discussed in our [model training tips guide](https://docs.ultralytics.com/guides/model-training-tips/).
 
 [![Ultralytics Actions](https://github.com/ultralytics/thop/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/thop/actions/workflows/format.yml)

--- a/tests/test_conv2d.py
+++ b/tests/test_conv2d.py
@@ -21,7 +21,7 @@ class TestUtils:
 
         _, _, oh, ow = out.shape
         print(f"Conv2d: in={ih}x{iw}, kernel={kh}x{kw}, stride={s}, padding={p}, out={oh}x{ow}")
-        macs, params = profile(net, inputs=(data,))
+        macs, _params = profile(net, inputs=(data,))
         assert macs == 810000, f"{macs} v.s. 810000"
 
     def test_conv2d(self):
@@ -36,7 +36,7 @@ class TestUtils:
 
         _, _, oh, ow = out.shape
         print(f"Conv2d: in={ih}x{iw}, kernel={kh}x{kw}, stride={s}, padding={p}, out={oh}x{ow}")
-        macs, params = profile(net, inputs=(data,))
+        macs, _params = profile(net, inputs=(data,))
         assert macs == 810000, f"{macs} v.s. 810000"
 
     def test_conv2d_random(self):
@@ -54,7 +54,7 @@ class TestUtils:
 
             _, _, oh, ow = out.shape
             print(f"Conv2d: in={ih}x{iw}, kernel={kh}x{kw}, stride={s}, padding={p}, out={oh}x{ow}")
-            macs, params = profile(net, inputs=(data,))
+            macs, _params = profile(net, inputs=(data,))
             assert macs == n * out_c * oh * ow // g * in_c * kh * kw, (
                 f"{macs} v.s. {n * out_c * oh * ow // g * in_c * kh * kw}"
             )

--- a/thop/__init__.py
+++ b/thop/__init__.py
@@ -9,4 +9,4 @@ from .utils import clever_format
 
 default_dtype = torch.float64
 
-__all__ = ["profile", "profile_origin", "clever_format", "default_dtype"]
+__all__ = ["clever_format", "default_dtype", "profile", "profile_origin"]

--- a/thop/fx_profile.py
+++ b/thop/fx_profile.py
@@ -49,11 +49,11 @@ def count_fn_conv2d(input_shapes, output_shapes, *args, **kwargs):
     """Calculates total operations (FLOPs) for a 2D conv layer based on input and output shapes using
     `calculate_conv`.
     """
-    inputs, weight, bias, stride, padding, dilation, groups = args
+    _inputs, _weight, _bias, _stride, _padding, _dilation, groups = args
     if len(input_shapes) == 2:
         x_shape, k_shape = input_shapes
     elif len(input_shapes) == 3:
-        x_shape, k_shape, b_shape = input_shapes
+        x_shape, k_shape, _b_shape = input_shapes
     out_shape = output_shapes[0]
 
     kernel_parameters = k_shape[2:].numel()

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -94,7 +94,7 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=
 
         if hasattr(m, "total_ops") or hasattr(m, "total_params"):
             logging.warning(
-                f"Either .total_ops or .total_params is already defined in {str(m)}. "
+                f"Either .total_ops or .total_params is already defined in {m!s}. "
                 "Be careful, it might change your code's behavior."
             )
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Minor refactors to improve code quality, readability, and linter compliance without changing functionality. ✅

### 📊 Key Changes
- Tests: Renamed unused `params` to `_params` in `tests/test_conv2d.py` to silence linter warnings.
- Exports: Reordered `__all__` in `thop/__init__.py` (no change to what’s exported).
- Conv2d profiling: Prefixed unused arguments with underscores in `thop/fx_profile.py` and `b_shape` -> `_b_shape` to indicate intentional non-use.
- Logging: Slight f-string improvement in `thop/profile.py` (`{m!s}` instead of `{str(m)}`) for clarity. 

### 🎯 Purpose & Impact
- Cleaner code and fewer linter warnings (helps maintainability and CI stability) 🧹
- No behavior changes or API breaks—safe for all users 🔒
- Slightly clearer logging messages for developers inspecting hooks 🪵