### PR TITLE
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,7 +138,7 @@ jobs:
           echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -146,7 +146,7 @@ jobs:
             text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `${{ github.repository }} ${{ needs.check.outputs.current_tag }}` pip package published 😃\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
       - name: Notify Failure
         if: needs.publish.result != 'success'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR makes a small but useful maintenance update by upgrading the Slack GitHub Action used in the package publishing workflow from `v3.0.1` to `v3.0.2`.

### 📊 Key Changes
- Updated the Slack notification action in `.github/workflows/publish.yml`:
  - `slackapi/slack-github-action@v3.0.1` → `slackapi/slack-github-action@v3.0.2`
- Applied the update to both workflow notification steps:
  - ✅ Success notifications
  - ❌ Failure notifications
- No changes were made to the package publishing logic itself or to THOP’s core functionality.

### 🎯 Purpose & Impact
- 🛠️ Keeps GitHub Actions dependencies up to date, which helps maintain workflow reliability and security.
- 📣 Ensures Slack alerts for publish success or failure continue using the latest patched action version.
- 🚀 Low-risk infrastructure improvement: users should not see any behavior change in THOP itself, but maintainers benefit from a more current CI/CD setup.
- ✅ Reduces the chance of issues caused by relying on an older action release during automated package publishing.