### PR TITLE
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,7 +138,7 @@ jobs:
           echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
@@ -146,7 +146,7 @@ jobs:
             text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `${{ github.repository }} ${{ needs.check.outputs.current_tag }}` pip package published 😃\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
       - name: Notify Failure
         if: needs.publish.result != 'success'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR updates the Slack GitHub Action used in the publish workflow from `v3.0.2` to `v3.0.3` to keep release notifications current and reliable.

### 📊 Key Changes
- ⬆️ Upgraded `slackapi/slack-github-action` in `.github/workflows/publish.yml`
  - Changed from `v3.0.2` to `v3.0.3`
- 📣 Applied the update to both Slack notification steps:
  - Success notifications after a package publish
  - Failure notifications when publishing does not succeed
- 🛠️ No changes were made to the publish logic itself, only to the notification action version

### 🎯 Purpose & Impact
- 🔒 Keeps the CI/CD workflow up to date with the latest patch release of the Slack action
- 📬 Helps maintain dependable Slack alerts for package publish success and failure events
- 🧹 A low-risk maintenance update that improves workflow hygiene without affecting users of the package directly
- 👨‍💻 For maintainers, this may reduce the chance of notification-related issues caused by using an older action version