### PR TITLE
Add Python 3.14 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/thop/__init__.py
+++ b/thop/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "2.0.19"
+__version__ = "2.0.20"
 
 import torch
 


### PR DESCRIPTION
## Summary
- advertise Python 3.14 support in package classifiers
- bump package patch version to 2.0.20

## Tests
- python -c "import thop; print(thop.__version__)"
- python -m build --sdist --wheel --outdir /tmp/thop-dist-check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR updates `thop` to version `2.0.20` and adds official Python 3.14 support metadata 🐍✨

### 📊 Key Changes
- Added `Python :: 3.14` to the package classifiers in `pyproject.toml`
- Bumped the package version in `thop/__init__.py` from `2.0.19` to `2.0.20`
- No functional code changes were introduced; this is primarily a compatibility and release metadata update

### 🎯 Purpose & Impact
- Improves package readiness for newer Python environments by declaring Python 3.14 support ✅
- Helps users, package indexes, and tooling correctly identify compatible Python versions
- Marks a new release (`2.0.20`) so the compatibility update can be distributed cleanly 📦
- Low risk for existing users since the PR does not change runtime logic or core features 👍