### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🚀 THOP: PyTorch-OpCounter
 
-Welcome to the [THOP](https://github.com/ultralytics/thop) repository, your comprehensive solution for profiling [PyTorch](https://pytorch.org/) models by computing the number of Multiply-Accumulate Operations (MACs) and parameters. Developed by Ultralytics, this tool is essential for [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) practitioners aiming to evaluate model efficiency and performance, crucial aspects discussed in our [model training tips guide](https://docs.ultralytics.com/guides/model-training-tips/).
+Welcome to the [THOP](https://github.com/ultralytics/thop) repository, your comprehensive solution for profiling [PyTorch](https://pytorch.org/) models by computing the number of Multiply-Accumulate Operations (MACs) and parameters. Maintained by Ultralytics, this tool is essential for [deep learning](https://www.ultralytics.com/glossary/deep-learning-dl) practitioners aiming to evaluate model efficiency and performance, crucial aspects discussed in our [model training tips guide](https://docs.ultralytics.com/guides/model-training-tips/).
 
 [![Ultralytics Actions](https://github.com/ultralytics/thop/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/thop/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
@@ -195,7 +195,7 @@ We actively welcome and encourage community contributions to make THOP even bett
 
 ## 📜 License
 
-THOP is distributed under the [AGPL-3.0 License](https://www.gnu.org/licenses/agpl-3.0.en.html). This license promotes open collaboration and sharing of improvements. For complete details, please refer to the [LICENSE](https://github.com/ultralytics/thop/blob/main/LICENSE) file included in the repository. Understanding the license is important before integrating THOP into your projects, especially for commercial applications which may require an [Enterprise License](https://www.ultralytics.com/license).
+THOP is distributed under the [AGPL-3.0 License](https://opensource.org/license/agpl-3.0). This license promotes open collaboration and sharing of improvements. For complete details, please refer to the [LICENSE](https://github.com/ultralytics/thop/blob/main/LICENSE) file included in the repository. Understanding the license is important before integrating THOP into your projects, especially for commercial applications which may require an [Enterprise License](https://www.ultralytics.com/license).
 
 ## 📧 Contact
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -39,4 +39,4 @@ This approach provides a standardized and reproducible way to compare the theore
 
 ## 🤝 Contributing
 
-Contributions to improve this documentation or the underlying library are always welcome! If you have suggestions or find inaccuracies, please refer to the main Ultralytics repository guidelines for contributing at [https://github.com/ultralytics/ultralytics](https://github.com/ultralytics/ultralytics). We appreciate your help in making our tools and resources better for the entire computer vision community. Check out our [contribution guide](https://docs.ultralytics.com/help/contributing/) for more detailed information on how to get involved.
+Contributions to improve this documentation or the underlying library are always welcome! If you have suggestions or find inaccuracies, please open an issue or pull request in the [THOP repository](https://github.com/ultralytics/thop). We appreciate your help in making our tools and resources better for the entire computer vision community. Check out our [contribution guide](https://docs.ultralytics.com/help/contributing/) for more detailed information on how to get involved.


### PR DESCRIPTION
## Summary
- updates THOP attribution to reflect Ultralytics maintenance of this forked package
- replaces a timing-out AGPL link with a responsive OSI license page
- points benchmark README contributions to the THOP repository

## Validation
- git diff --check
- lychee README.md benchmark/README.md --no-progress --accept 200,204,206,301,302,429 --exclude 'https://twitter.com/ultralytics'
- thop import/API smoke check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes small but useful documentation updates to THOP, clarifying project ownership, improving license links, and directing contributors to the correct repository.

### 📊 Key Changes
- Updated the main `README.md` to say THOP is **maintained by Ultralytics** instead of “developed by Ultralytics” 🤝
- Replaced the AGPL-3.0 license link with a more standard **Open Source Initiative license page** 🔗
- Fixed contribution guidance in `benchmark/README.md` so users are told to open issues or PRs in the **THOP repository**, not the main Ultralytics repo 🛠️
- Kept the rest of the documentation intact, with no code or functionality changes ✅

### 🎯 Purpose & Impact
- Improves documentation accuracy and reduces confusion for users and contributors 📚
- Helps community members submit feedback and pull requests in the right place, which can streamline project maintenance 🚀
- Makes licensing information easier to reference and more standardized for developers evaluating usage terms ⚖️
- Has **no impact on THOP’s runtime behavior or profiling results**—this is a documentation-only cleanup 🧹