### PR TITLE
Simplify Slack notification messages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,16 +126,15 @@ jobs:
       contents: read
       statuses: read
     steps:
-      - uses: actions/checkout@v7
-      - name: Extract PR Details
+      - name: Get release title
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.check.outputs.current_tag }}
         run: |
-          PR_JSON=$(gh pr list --search "${GITHUB_SHA}" --state merged --json number,title --jq '.[0]')
-          PR_NUMBER=$(echo "${PR_JSON}" | jq -r '.number')
-          PR_TITLE=$(echo "${PR_JSON}" | jq -r '.title' | sed 's/"/\\"/g')
-          echo "PR_NUMBER=${PR_NUMBER}" >> "${GITHUB_ENV}"
-          echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
+          TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'
         uses: slackapi/slack-github-action@v3.0.3
@@ -143,7 +142,7 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `${{ github.repository }} ${{ needs.check.outputs.current_tag }}` pip package published 😃\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
         if: needs.publish.result != 'success'
         uses: slackapi/slack-github-action@v3.0.3
@@ -151,4 +150,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ❌ `${{ github.repository }}` ${{ needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"


### PR DESCRIPTION
Replaces the verbose multi-line Slack notifications with a single dense line — bold workflow name, status emoji, `${{ github.repository }}`, and a *Run* backlink — matching the format used in `ultralytics/portal`.

- Scopes the broad `<!channel>` ping down to `@yolo-team` to cut company-wide notification noise.
- Publish notifications surface the GitHub release title + *Release* link; the now-dead `Extract PR Details` step is replaced by a lean `gh release view` step.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR simplifies the publish workflow’s Slack notifications by switching from PR-based metadata to release-based metadata, making release alerts cleaner and more reliable.

### 📊 Key Changes
- Replaced the step that searched for merged PR details with a new step that fetches the **release title** directly from the GitHub release associated with the published tag.
- Removed the need to:
  - check out the repository in this notification job
  - parse PR number and PR title from `gh pr list`
  - store PR info in environment variables
- Updated the **success Slack message** to:
  - mention a specific Slack subteam instead of `@channel`
  - show the workflow name, repository, and release title or tag
  - include direct links to the **GitHub Release** and **workflow run**
- Updated the **failure Slack message** to:
  - use the same Slack subteam mention
  - provide a shorter, cleaner alert with a direct link to the workflow run
- Added fallback behavior so if the release title is unavailable, the workflow uses the tag name instead.

### 🎯 Purpose & Impact
- ✅ **More accurate notifications:** Release alerts now reflect the actual published release instead of trying to infer context from a merged PR.
- ⚡ **Simpler workflow logic:** Fewer steps and less parsing reduce maintenance burden and the chance of notification failures.
- 🧹 **Cleaner Slack messages:** Notifications are shorter, easier to read, and focus on the most useful links and release info.
- 🎯 **Better team targeting:** Using a specific Slack subteam helps notify the right people without broadcasting to everyone.
- 🛡️ **Improved reliability:** The fallback to the tag name ensures alerts still work even if the release title cannot be fetched.