### PR TITLE
Linkify PR numbers in publish Slack notifications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -134,6 +134,7 @@ jobs:
           TAG: ${{ needs.check.outputs.current_tag }}
         run: |
           TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          TITLE=$(printf '%s' "$TITLE" | sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g")
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'


### PR DESCRIPTION
Turns the `#<number>` PR reference inside the GitHub release title into a clickable link to the PR in the **Publish to PyPI** success notification, e.g. `(#24965)` → [`#24965`](pull link).

- One line added to the existing `Get release title` step: `sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g"`.
- No-ops on titles without a `#<number>`; `/pull/N` auto-redirects to `/issues/N` if it ever isn't a PR.
- All Slack `text:` payload lines are unchanged — the link is built at the source where the title is fetched.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR improves release notifications by automatically turning pull request references like `#123` in release titles into clickable GitHub links.

### 📊 Key Changes
- Added a new step in `.github/workflows/publish.yml` to process release titles before sending success notifications.
- Updated the workflow to detect PR references in the title, such as `#123`.
- Replaced plain PR numbers with formatted links pointing directly to the corresponding pull request in the current repository.

### 🎯 Purpose & Impact
- Makes release notifications more user-friendly by letting readers click straight to the referenced PRs 🔗
- Improves traceability, so developers and users can quickly see what changes are included in a release.
- Enhances automation in the publishing workflow with a small but practical quality-of-life improvement ⚡