### PR TITLE
Harden publish workflow recovery, notifications, and dispatch guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   check:
-    if: github.repository == 'ultralytics/thop' && github.actor == 'glenn-jocher'
+    if: github.repository == 'ultralytics/thop' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -32,13 +32,17 @@ jobs:
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
+        env:
+          PYPI_DISPATCH: ${{ github.event.inputs.pypi }}
         run: |
           import os
           from actions.utils import check_pypi_version
           local_version, online_version, publish = check_pypi_version()
+          publish = publish or os.environ.get("PYPI_DISPATCH") == "true"  # manual recovery re-run
           os.system(f'echo "increment={publish}" >> $GITHUB_OUTPUT')
           os.system(f'echo "current_tag=v{local_version}" >> $GITHUB_OUTPUT')
-          os.system(f'echo "previous_tag=v{online_version}" >> $GITHUB_OUTPUT')
+          if online_version != local_version:  # empty on recovery re-runs so summarize falls back to the true previous tag
+              os.system(f'echo "previous_tag=v{online_version}" >> $GITHUB_OUTPUT')
           if publish:
               print('Ready to publish new version to PyPI ✅.')
       - name: Tag and Release
@@ -49,11 +53,16 @@ jobs:
           PREVIOUS_TAG: ${{ steps.check_pypi.outputs.previous_tag }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          git config --global user.name "UltralyticsAssistant"
-          git config --global user.email "web@ultralytics.com"
-          git tag -a "$CURRENT_TAG" -m "$(git log -1 --pretty=%B)"
-          git push origin "$CURRENT_TAG"
-          ultralytics-actions-summarize-release
+          if [ -z "$(git ls-remote --tags origin "refs/tags/$CURRENT_TAG")" ]; then
+            git config --global user.name "UltralyticsAssistant"
+            git config --global user.email "web@ultralytics.com"
+            git tag -a "$CURRENT_TAG" -m "$(git log -1 --pretty=%B)"
+            git push origin "$CURRENT_TAG"
+          fi
+          if ! gh release view "$CURRENT_TAG" >/dev/null 2>&1; then
+            [ -n "$PREVIOUS_TAG" ] || git fetch --unshallow --tags # summarize resolves the previous tag from git history
+            ultralytics-actions-summarize-release
+          fi
           uv cache prune --ci
 
   build:
@@ -91,6 +100,8 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true # tolerate recovery re-runs after partial failures
 
   sbom:
     needs: [check, build, publish]
@@ -114,12 +125,12 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
           path: sbom-env
-      - run: gh release upload ${{ needs.check.outputs.current_tag }} sbom.spdx.json
+      - run: gh release upload ${{ needs.check.outputs.current_tag }} sbom.spdx.json --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify:
-    needs: [check, publish]
+    needs: [check, publish, sbom]
     if: always() && needs.check.outputs.increment == 'True'
     runs-on: ubuntu-latest
     permissions:
@@ -137,7 +148,7 @@ jobs:
           TITLE=$(printf '%s' "$TITLE" | sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g")
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
-        if: needs.publish.result == 'success' && github.event_name == 'push'
+        if: needs.publish.result == 'success' && needs.sbom.result == 'success' && github.event_name == 'push'
         uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
@@ -145,7 +156,7 @@ jobs:
           payload: |
             text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
-        if: needs.publish.result != 'success'
+        if: needs.publish.result != 'success' || needs.sbom.result != 'success'
         uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook


### PR DESCRIPTION
## 🛠️ Summary

Ports the release-workflow hardening from [ultralytics/template#91](https://github.com/ultralytics/template/pull/91) (and matching PRs in mkdocs/ultralytics). The `publish.yml` pipeline previously had no recovery path after a partial failure, and Slack could report success before the pipeline finished.

### 1. Failed releases can now be recovered via `workflow_dispatch`
Once the tag is pushed, any downstream failure (build, PyPI upload, SBOM) previously left the release unrecoverable — a re-run hit `git tag -a` on the existing tag and the `check` job died. Now, when the `pypi` dispatch input is checked, the run proceeds as a recovery re-run:
- `workflow_dispatch` with `pypi: true` forces `increment=True`
- Tagging is skipped when the tag already exists on origin (`git ls-remote`)
- Release summarization is gated independently on release existence (`gh release view`), healing the tag-pushed-but-no-release state, and unshallows history first so the changelog resolves the true previous tag
- `previous_tag` output is omitted on recovery re-runs (online == local) so the summarizer falls back to the real previous tag instead of comparing `vX...vX`
- PyPI upload uses `skip-existing: true`; SBOM upload uses `--clobber`

A partially failed release can be re-run from any point and completes only what is missing.

### 2. Slack success can no longer fire prematurely
`notify` now includes `sbom` in `needs` and in the success/failure conditions, so the ✅ message reflects the entire pipeline rather than racing the SBOM job.

### 3. `workflow_dispatch` can no longer release a non-main commit
The `check` job now requires `github.ref == 'refs/heads/main'`.

## 🧪 Testing

- YAML validated
- Same change reviewed through multiple adversarial Codex review rounds (to LGTM) on ultralytics/template#91, mkdocs, and ultralytics; the no-failure happy path is behavior-identical to the current workflow.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the THOP release workflow to make PyPI publishing, GitHub releases, SBOM uploads, and Slack notifications more reliable and recoverable 🚀

### 📊 Key Changes
- Restricts automated release checks to the `main` branch only, reducing accidental publishing from other branches 🔒
- Adds support for manual PyPI dispatch recovery using the `pypi` workflow input 🛠️
- Prevents duplicate Git tags and GitHub releases by checking whether they already exist before creating them ✅
- Enables PyPI publishing with `skip-existing: true` to tolerate reruns after partial failures 📦
- Updates SBOM release uploads to use `--clobber`, allowing replacement of existing SBOM files ♻️
- Makes Slack notifications depend on both PyPI publishing and SBOM generation/upload success 📣
- Improves previous-tag handling so release summaries can still work correctly during recovery reruns 📝

### 🎯 Purpose & Impact
- Makes the release pipeline more resilient to interrupted or partially failed publishing runs 💪
- Reduces risk of duplicate tags, duplicate releases, or failed reruns when artifacts already exist 🚧
- Improves release transparency by ensuring SBOM artifacts are included before success notifications are sent 🔍
- Helps maintainers recover failed releases more easily without manual cleanup or risky workarounds ⚙️
- Provides users with more consistent and trustworthy package releases on PyPI and GitHub Releases 🌍