### PR TITLE
Replace third-party CLA action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,7 +3,7 @@
 # Ultralytics Contributor License Agreement (CLA) action https://docs.ultralytics.com/help/CLA
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 
-name: CLA Assistant
+name: CLA
 on:
   issue_comment:
     types:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,12 +20,12 @@ permissions:
 
 jobs:
   CLA:
-    if: github.repository == 'ultralytics/thop' && (github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA')))
+    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA'))
     concurrency:
       group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest
     steps:
-      - name: CLA Assistant
+      - name: CLA
         uses: ultralytics/actions/cla@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,8 @@
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 
 name: CLA Assistant
+concurrency:
+  group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
 on:
   issue_comment:
     types:
@@ -16,30 +18,16 @@ on:
 
 permissions:
   actions: write
-  contents: write
   pull-requests: write
-  statuses: write
 
 jobs:
   CLA:
-    if: github.repository == 'ultralytics/thop'
+    if: github.repository == 'ultralytics/thop' && (github.event_name != 'issue_comment' || github.event.issue.pull_request)
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Must be repository secret PAT
-          PERSONAL_ACCESS_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+        uses: ultralytics/actions/cla@43945a7d2364fc943becb0245a4edcb05e49427f
         with:
-          path-to-signatures: "signatures/version1/cla.json"
-          path-to-document: "https://docs.ultralytics.com/help/CLA" # CLA document
-          # Branch must not be protected
-          branch: cla-signatures
-          allowlist: dependabot[bot],github-actions,[pre-commit*,pre-commit*,bot*
-
-          remote-organization-name: ultralytics
-          remote-repository-name: cla
-          custom-pr-sign-comment: "I have read the CLA Document and I sign the CLA"
-          custom-allsigned-prcomment: All Contributors have signed the CLA. ✅
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cla-token: ${{ secrets._GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,8 +4,6 @@
 # This workflow automatically requests Pull Requests (PR) authors to sign the Ultralytics CLA before PRs can be merged
 
 name: CLA Assistant
-concurrency:
-  group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
 on:
   issue_comment:
     types:
@@ -22,12 +20,13 @@ permissions:
 
 jobs:
   CLA:
-    if: github.repository == 'ultralytics/thop' && (github.event_name != 'issue_comment' || github.event.issue.pull_request)
+    if: github.repository == 'ultralytics/thop' && (github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA')))
+    concurrency:
+      group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA') || github.event_name == 'pull_request_target'
-        uses: ultralytics/actions/cla@43945a7d2364fc943becb0245a4edcb05e49427f
+        uses: ultralytics/actions/cla@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cla-token: ${{ secrets._GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- replace the third-party CLA runtime and duplicated configuration with the canonical `ultralytics/actions` workflow
- use `ultralytics/actions/cla@main` so repositories inherit shared fixes automatically
- keep event routing at the job boundary and grant only `actions: write` and `pull-requests: write`
- keep the ledger PAT isolated to the CLA step and central `ultralytics/cla` repository

Deleted: `contributor-assistant/github-action`, its duplicated ledger path, branch, repository, comment, and allowlist configuration, the PAT environment mapping, unused permissions, workflow-level concurrency, and step-level event filtering.

Reused: the canonical `ultralytics/actions/.github/workflows/cla.yml` structure and shared `ultralytics/actions/cla@main` implementation.

## Validation

- byte-for-byte comparison with the reviewed `ultralytics/actions/.github/workflows/cla.yml` template
- `actionlint .github/workflows/cla.yml`
- `npx prettier --write .github/workflows/cla.yml`
- stale third-party and pinned-action scan
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔐 Simplifies the repository’s CLA workflow by replacing the third-party action with Ultralytics’ centralized CLA action.

### 📊 Key Changes

- Renamed the workflow from **“CLA Assistant”** to **“CLA”**.
- Replaced `contributor-assistant/github-action` with `ultralytics/actions/cla@main`.
- Simplified workflow permissions by removing unnecessary `contents` and `statuses` write access.
- Added concurrency control to prevent overlapping CLA checks for the same pull request.
- Updated job conditions to handle pull request events and contributor CLA confirmation comments.
- Continued using repository secrets for GitHub and CLA authentication.

### 🎯 Purpose & Impact

- ✅ Centralizes CLA enforcement across Ultralytics repositories for easier maintenance.
- 🔒 Reduces workflow permissions, improving repository security.
- ⚡ Prevents duplicate or conflicting CLA checks through concurrency controls.
- 🛠️ Maintains the existing contributor-signing process with less custom configuration.
- 📦 No changes to THOP functionality or runtime behavior; the impact is limited to contribution and pull request automation.