### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache build
       - run: python -m build
       - uses: actions/upload-artifact@v7
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - run: |
           uv venv sbom-env
           uv pip install -e .


### PR DESCRIPTION
## Summary
- replace all 3 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 3 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔧 Updated the publishing workflow to use Ultralytics’ centralized `setup-uv` GitHub Action.

### 📊 Key Changes

- Replaced `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main`.
- Applied the change across package publishing, build, and SBOM generation jobs.
- Kept the existing Python, dependency installation, build, and artifact upload steps unchanged.

### 🎯 Purpose & Impact

- ✅ Standardizes `uv` setup across Ultralytics repositories.
- 🛠️ Enables centralized maintenance and updates for the workflow action.
- 🚀 Helps keep release automation consistent while preserving the current publishing behavior.
- ⚠️ Because the workflow tracks the `main` branch, future action changes could affect builds without a version pin.