### PR TITLE
Remove leaked profiling buffers from all modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If your model includes custom or third-party modules not natively supported by T
 
 ```python
 import torch
-import torch.nn as nn
+from torch import nn
 
 from thop import profile
 

--- a/benchmark/evaluate_rnn_models.py
+++ b/benchmark/evaluate_rnn_models.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 from thop.profile import profile
 

--- a/tests/test_conv2d.py
+++ b/tests/test_conv2d.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 from thop import profile
 

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 from thop import profile
 

--- a/tests/test_relu.py
+++ b/tests/test_relu.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 from thop import profile
 

--- a/thop/__init__.py
+++ b/thop/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "2.0.20"
+__version__ = "2.0.21"
 
 import torch
 

--- a/thop/fx_profile.py
+++ b/thop/fx_profile.py
@@ -5,7 +5,7 @@ from distutils.version import LooseVersion
 
 import torch
 import torch as th
-import torch.nn as nn
+from torch import nn
 from torch.fx import symbolic_trace
 from torch.fx.passes.shape_prop import ShapeProp
 

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -240,11 +240,12 @@ def profile(
 
     # reset model to original status
     model.train(prev_training_status)
-    for m, (op_handler, params_handler) in handler_collection.items():
+    for op_handler, params_handler in handler_collection.values():
         op_handler.remove()
         params_handler.remove()
-        m._buffers.pop("total_ops")
-        m._buffers.pop("total_params")
+    for m in model.modules():  # add_hooks ran on every module, so every module carries the temporary buffers
+        m._buffers.pop("total_ops", None)
+        m._buffers.pop("total_params", None)
 
     if ret_layer_info:
         return total_ops, total_params, ret_dict

--- a/thop/rnn_hooks.py
+++ b/thop/rnn_hooks.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-import torch.nn as nn
+from torch import nn
 from torch.nn.utils.rnn import PackedSequence
 
 

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -3,7 +3,7 @@
 import logging
 
 import torch
-import torch.nn as nn
+from torch import nn
 from torch.nn.modules.conv import _ConvNd
 
 from thop.vision.calc_func import (


### PR DESCRIPTION
## summary

`profile()` registered `total_ops`/`total_params` buffers on every module via `model.apply(add_hooks)`, but the cleanup loop only popped them from modules in `handler_collection` — the modules whose type had a registered op-counting rule. Modules with no rule (activations like the shared `nn.SiLU` singleton, container modules, the root model) kept the float64 buffers permanently, so they leaked into `state_dict()` and, through shared activation singletons, spread to other models built later in the same process.

cleanup now removes the forward hooks for every hooked module and pops the buffers from every module in `model.modules()` (the exact set `add_hooks` touched), so profiling is side-effect-free. verified: a model built after profiling goes from 210 leaked keys to 0, returned FLOPs/params are unchanged, and the existing test suite passes.

Deleted: the buffer-pop coupled to `handler_collection` iteration (missed every rule-less module).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

THOP 2.0.21 improves profiling cleanup reliability and standardizes PyTorch imports across the project. 🧹

### 📊 Key Changes

- Updated the package version from `2.0.20` to `2.0.21`.
- Improved temporary profiling buffer cleanup by removing `total_ops` and `total_params` safely from every model module.
- Simplified hook cleanup by iterating directly over registered handler values.
- Standardized imports from `import torch.nn as nn` to `from torch import nn` across documentation, tests, benchmarks, and source files.
- Updated affected RNN, FX, vision hook, and test modules without changing their functional behavior.

### 🎯 Purpose & Impact

- 🛠️ Prevents cleanup errors when profiling models with modules that may not contain temporary buffers.
- ✅ Makes repeated profiling and profiling of complex model hierarchies more robust.
- 📦 Provides a maintenance release with clearer, more consistent code style.
- 🚀 Existing THOP users should see improved reliability without needing to change their profiling code.