### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If your model includes custom or third-party modules not natively supported by T
 
 ```python
 import torch
-import torch.nn as nn
+from torch import nn
 
 from thop import profile
 

--- a/benchmark/evaluate_rnn_models.py
+++ b/benchmark/evaluate_rnn_models.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 from thop.profile import profile
 

--- a/tests/test_conv2d.py
+++ b/tests/test_conv2d.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 from thop import profile
 

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 from thop import profile
 

--- a/tests/test_relu.py
+++ b/tests/test_relu.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 from thop import profile
 

--- a/thop/fx_profile.py
+++ b/thop/fx_profile.py
@@ -5,7 +5,7 @@ from distutils.version import LooseVersion
 
 import torch
 import torch as th
-import torch.nn as nn
+from torch import nn
 from torch.fx import symbolic_trace
 from torch.fx.passes.shape_prop import ShapeProp
 

--- a/thop/rnn_hooks.py
+++ b/thop/rnn_hooks.py
@@ -1,7 +1,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-import torch.nn as nn
+from torch import nn
 from torch.nn.utils.rnn import PackedSequence
 
 

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -3,7 +3,7 @@
 import logging
 
 import torch
-import torch.nn as nn
+from torch import nn
 from torch.nn.modules.conv import _ConvNd
 
 from thop.vision.calc_func import (


### PR DESCRIPTION
## Summary

Applies the Ruff 0.16.0 import compatibility fixes produced by the latest Ultralytics Actions settings, including the Python 3.8 target and global BLE001/S110 ignores.

## Validation

- `ruff 0.16.0 check --fix --unsafe-fixes` with the Actions rule set
- `ruff 0.16.0 format --line-length 120 .`
- `python -m compileall -q .`
- `python -m pytest tests/` (16 passed)

Deleted: nothing; the migration only replaces existing `torch.nn` import forms, so no behavior or code path is superseded.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Standardizes PyTorch `nn` imports across THOP source code, tests, benchmarks, and documentation without changing functionality.

### 📊 Key Changes

- Replaced `import torch.nn as nn` with `from torch import nn` in:
  - Core profiling modules, including FX and RNN support.
  - Vision hook implementations.
  - Convolution, matrix multiplication, and ReLU tests.
  - RNN benchmarks.
  - README usage examples.
- No profiling logic, APIs, or test behavior was changed.

### 🎯 Purpose & Impact

- ✅ Improves import consistency and code readability across the repository.
- 🧩 Maintains identical runtime behavior and compatibility.
- 🧪 Keeps examples, tests, and implementation files aligned with the preferred PyTorch import style.
- 🚀 This is a maintenance-only change with no direct user-facing feature impact.