### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,13 @@ from thop import profile
 # Define your custom module
 class YourCustomModule(nn.Module):
     def __init__(self):
+        """Initialize the example convolution layer."""
         super().__init__()
         # Define layers, e.g., a convolution
         self.conv = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1)
 
     def forward(self, x):
+        """Apply the example convolution layer."""
         return self.conv(x)
 
 

--- a/thop/fx_profile.py
+++ b/thop/fx_profile.py
@@ -13,7 +13,7 @@ from .utils import prRed, prYellow
 from .vision.calc_func import calculate_conv
 
 if LooseVersion(torch.__version__) < LooseVersion("1.8.0"):
-    logging.warning(
+    logging.getLogger(__name__).warning(
         f"torch.fx requires version higher than 1.8.0. But You are using an old version PyTorch {torch.__version__}. "
     )
 

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -158,7 +158,7 @@ def count_upsample(m, x, y):
         "bicubic",
         "trilinear",
     ):
-        logging.warning(f"mode {m.mode} is not implemented yet, take it a zero op")
+        logging.getLogger(__name__).warning(f"mode {m.mode} is not implemented yet, take it a zero op")
         m.total_ops += 0
     else:
         x = x[0]


### PR DESCRIPTION
Fixes the remaining Ruff 0.16.0 source diagnostics and the README Python snippet diagnostics found in Actions run 30052682577.\n\nValidation:\n- Ruff 0.16.0 check and format\n- Ultralytics Actions Markdown code-block formatter\n- 16 pytest tests passed\n\nDeleted: direct root-logger calls.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves THOP logging practices and clarifies the custom module example documentation. 🛠️

### 📊 Key Changes

- Replaced root-level `logging.warning()` calls with module-specific logger calls using `logging.getLogger(__name__).warning()`.
- Updated warnings in `fx_profile.py` and `basic_hooks.py` without changing profiling behavior.
- Added docstrings to the README’s custom PyTorch module example for initialization and forward-pass methods.

### 🎯 Purpose & Impact

- 🧹 Improves logging consistency and allows applications to configure THOP warnings more precisely.
- 🔍 Preserves existing warnings for unsupported PyTorch versions and unimplemented upsampling modes.
- 📚 Makes the custom module example clearer and more maintainable for users extending THOP.
- ⚙️ No expected change to computational profiling results or runtime functionality.