### PR TITLE
Leave no hooks or buffers behind when profiling fails or shares modules

### DIFF
--- a/thop/__init__.py
+++ b/thop/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "2.0.21"
+__version__ = "2.0.22"
 
 import torch
 

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -179,6 +179,9 @@ def profile(
 
     def add_hooks(m: nn.Module):
         """Registers hooks to a neural network module to track total operations and parameters."""
+        if m in handler_collection:  # model.apply() revisits modules shared by several parents, e.g. a common act
+            return
+
         m.register_buffer("total_ops", torch.zeros(1, dtype=torch.float64))
         m.register_buffer("total_params", torch.zeros(1, dtype=torch.float64))
 
@@ -208,14 +211,6 @@ def profile(
             )
         types_collection.add(m_type)
 
-    prev_training_status = model.training
-
-    model.eval()
-    model.apply(add_hooks)
-
-    with torch.no_grad():
-        model(*inputs)
-
     def dfs_count(module: nn.Module, prefix="\t") -> (int, int):
         """Recursively counts the total operations and parameters of the given PyTorch module and its submodules."""
         total_ops, total_params = module.total_ops.item(), module.total_params.item()
@@ -236,16 +231,24 @@ def profile(
         # print(prefix, module._get_name(), (total_ops, total_params))
         return total_ops, total_params, ret_dict
 
-    total_ops, total_params, ret_dict = dfs_count(model)
+    prev_training_status = model.training
 
-    # reset model to original status
-    model.train(prev_training_status)
-    for op_handler, params_handler in handler_collection.values():
-        op_handler.remove()
-        params_handler.remove()
-    for m in model.modules():  # add_hooks ran on every module, so every module carries the temporary buffers
-        m._buffers.pop("total_ops", None)
-        m._buffers.pop("total_params", None)
+    model.eval()
+    model.apply(add_hooks)
+
+    try:
+        with torch.no_grad():
+            model(*inputs)
+        total_ops, total_params, ret_dict = dfs_count(model)
+    finally:  # a failed forward pass must not leave hooks or buffers behind
+        # reset model to original status
+        model.train(prev_training_status)
+        for op_handler, params_handler in handler_collection.values():
+            op_handler.remove()
+            params_handler.remove()
+        for m in model.modules():  # add_hooks ran on every module, so every module carries the temporary buffers
+            m._buffers.pop("total_ops", None)
+            m._buffers.pop("total_params", None)
 
     if ret_layer_info:
         return total_ops, total_params, ret_dict

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -211,6 +211,8 @@ def profile(
             )
         types_collection.add(m_type)
 
+    counted = set()
+
     def dfs_count(module: nn.Module, prefix="\t") -> (int, int):
         """Recursively counts the total operations and parameters of the given PyTorch module and its submodules."""
         total_ops, total_params = module.total_ops.item(), module.total_params.item()
@@ -226,6 +228,9 @@ def profile(
             else:
                 m_ops, m_params, next_dict = dfs_count(m, prefix=prefix + "\t")
             ret_dict[n] = (m_ops, m_params, next_dict)
+            if m in counted:  # a module reached through several parents already accumulated all of its calls
+                continue
+            counted.add(m)
             total_ops += m_ops
             total_params += m_params
         # print(prefix, module._get_name(), (total_ops, total_params))
@@ -233,14 +238,13 @@ def profile(
 
     prev_training_status = model.training
 
-    model.eval()
-    model.apply(add_hooks)
-
     try:
+        model.eval()
+        model.apply(add_hooks)
         with torch.no_grad():
             model(*inputs)
         total_ops, total_params, ret_dict = dfs_count(model)
-    finally:  # a failed forward pass must not leave hooks or buffers behind
+    finally:  # no failure, at any stage, may leave hooks or buffers behind
         # reset model to original status
         model.train(prev_training_status)
         for op_handler, params_handler in handler_collection.values():


### PR DESCRIPTION
## Summary

Follow-up to #137, which made `profile()` clean up buffers on the success path. Two paths still left state on the caller's model, and both must be closed before `ultralytics` can drop its `deepcopy(model)` workaround in `get_flops()`.

**1. Failed forward pass left everything behind.** If `model(*inputs)` raised, neither the hooks nor the buffers were removed. Cleanup now runs in a `finally`.

**2. Modules shared by several parents leaked hook handles.** `model.apply(add_hooks)` visits a module once *per parent*, so a module reachable from several parents was hooked repeatedly while `handler_collection[m] = (...)` kept only the last pair — every earlier pair was orphaned and unremovable. `add_hooks` now returns early for a module it has already hooked.

This one bites hard: the orphaned hooks reference the `total_ops` buffer that cleanup removes, so the model is left **permanently broken**. On `rtdetr-l`, 6 `nn.ReLU` objects are each shared by 8 parents:

```python
thop.profile(model, inputs=[torch.empty(1, 3, 32, 32)])  # raises, as it does for RTDETR
model(torch.zeros(1, 3, 640, 640))
# AttributeError: 'ReLU' object has no attribute 'total_ops'
```

| `rtdetr-l` after a failed profile | before | after |
| --- | --- | --- |
| orphaned forward hooks | 84 | 0 |
| leftover buffers | 0 | 0 |
| subsequent forward pass | `AttributeError` | OK |

Both bugs predate #137 — `ultralytics` never hit them only because it profiles a `deepcopy`.

## Verification

Counts are unchanged everywhere, including with the `deepcopy` removed — `profile(m)` and `profile(deepcopy(m))` return identical values for `yolo11n` (6.6143 GFLOPs), `rtdetr-l` (108.3437 GFLOPs), and weight-tied models.

Repeated `get_flops`-style calls on `rtdetr-l`, which exercise the failing-then-succeeding two-method path:

| call | before | after |
| --- | --- | --- |
| 1st | 216.687 GFLOPs | 108.344 GFLOPs |
| 2nd | 325.031 GFLOPs | 108.344 GFLOPs |
| 3rd | 433.375 GFLOPs | 108.344 GFLOPs |

Before, each call stacked another set of hooks onto the model, inflating the result without bound; the true value is ~108. Also verified: the original exception still propagates, training mode is restored on failure, and shared submodules, `custom_ops`, `ret_layer_info`, `ModuleList`/`ModuleDict` and `profile_origin` are all unaffected. 16/16 tests pass; ruff clean.

## Known limitation, not addressed here

`dfs_count` walks `named_children()` and so visits a shared module once per parent, over-counting weight-tied models (a 4-way tied conv reports 184320 MACs against a true 73728). That is a pre-existing accuracy bug independent of this cleanup work — `deepcopy` preserves sharing and produces the identical wrong number — and no Ultralytics model is affected, since their shared modules (`SiLU`, `ReLU`) carry no params and no ops. Worth its own PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ THOP 2.0.22 improves operation and parameter profiling for models with shared modules and ensures cleanup after profiling failures.

### 📊 Key Changes

- 🔖 Bumped the package version from `2.0.21` to `2.0.22`.
- ♻️ Prevented duplicate hook registration when `model.apply()` encounters shared modules.
- 📈 Added tracking to count shared modules only once, avoiding duplicated operation and parameter totals.
- 🧹 Wrapped profiling in `try/finally` to always remove temporary hooks and buffers and restore the model’s original training state.

### 🎯 Purpose & Impact

- ✅ Produces more accurate FLOPs and parameter estimates for architectures that reuse layers or activation modules.
- 🛡️ Prevents profiling errors from leaving models modified with stale hooks, buffers, or evaluation mode.
- 🔒 Improves reliability for repeated profiling runs and complex PyTorch model architectures.