### PR TITLE
Refresh README and YOLO benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,32 +96,58 @@ print(f"Formatted MACs: {macs_readable}, Formatted Parameters: {params_readable}
 
 The following detection models were profiled at 640 × 640 from their fused architecture definitions. Install `ultralytics`, then run `python benchmark/evaluate_famous_models.py` to reproduce the table without downloading model weights. FLOPs are often approximated as twice the MAC count.
 
-| Model                                                  | Params (M) | MACs (G) |
-| ------------------------------------------------------ | ---------- | -------- |
-| [YOLOv8n](https://docs.ultralytics.com/models/yolov8/) | 3.15       | 4.37     |
-| YOLOv8s                                                | 11.16      | 14.30    |
-| YOLOv8m                                                | 25.89      | 39.47    |
-| YOLOv8l                                                | 43.67      | 82.58    |
-| YOLOv8x                                                | 68.20      | 128.91   |
-| [YOLO11n](https://docs.ultralytics.com/models/yolo11/) | 2.62       | 3.24     |
-| YOLO11s                                                | 9.44       | 10.74    |
-| YOLO11m                                                | 20.09      | 33.99    |
-| YOLO11l                                                | 25.34      | 43.46    |
-| YOLO11x                                                | 56.92      | 97.46    |
-| [YOLO26n](https://docs.ultralytics.com/models/yolo26/) | 2.41       | 2.68     |
-| YOLO26s                                                | 9.50       | 10.35    |
-| YOLO26m                                                | 20.41      | 34.09    |
-| YOLO26l                                                | 24.81      | 43.22    |
-| YOLO26x                                                | 55.73      | 96.94    |
+| Model                                                                  | size<br><sup>(pixels)</sup> | params<br><sup>(M)</sup> | MACs<br><sup>(B)</sup> |
+| ---------------------------------------------------------------------- | --------------------------- | ------------------------ | ---------------------- |
+| [YOLOv8n](https://platform.ultralytics.com/ultralytics/yolov8/yolov8n) | 640                         | 3.15                     | 4.37                   |
+| [YOLOv8s](https://platform.ultralytics.com/ultralytics/yolov8/yolov8s) | 640                         | 11.16                    | 14.30                  |
+| [YOLOv8m](https://platform.ultralytics.com/ultralytics/yolov8/yolov8m) | 640                         | 25.89                    | 39.47                  |
+| [YOLOv8l](https://platform.ultralytics.com/ultralytics/yolov8/yolov8l) | 640                         | 43.67                    | 82.58                  |
+| [YOLOv8x](https://platform.ultralytics.com/ultralytics/yolov8/yolov8x) | 640                         | 68.20                    | 128.91                 |
+| [YOLO11n](https://platform.ultralytics.com/ultralytics/yolo11/yolo11n) | 640                         | 2.62                     | 3.24                   |
+| [YOLO11s](https://platform.ultralytics.com/ultralytics/yolo11/yolo11s) | 640                         | 9.44                     | 10.74                  |
+| [YOLO11m](https://platform.ultralytics.com/ultralytics/yolo11/yolo11m) | 640                         | 20.09                    | 33.99                  |
+| [YOLO11l](https://platform.ultralytics.com/ultralytics/yolo11/yolo11l) | 640                         | 25.34                    | 43.46                  |
+| [YOLO11x](https://platform.ultralytics.com/ultralytics/yolo11/yolo11x) | 640                         | 56.92                    | 97.46                  |
+| [YOLO26n](https://platform.ultralytics.com/ultralytics/yolo26/yolo26n) | 640                         | 2.41                     | 2.68                   |
+| [YOLO26s](https://platform.ultralytics.com/ultralytics/yolo26/yolo26s) | 640                         | 9.50                     | 10.35                  |
+| [YOLO26m](https://platform.ultralytics.com/ultralytics/yolo26/yolo26m) | 640                         | 20.41                    | 34.09                  |
+| [YOLO26l](https://platform.ultralytics.com/ultralytics/yolo26/yolo26l) | 640                         | 24.81                    | 43.22                  |
+| [YOLO26x](https://platform.ultralytics.com/ultralytics/yolo26/yolo26x) | 640                         | 55.73                    | 96.94                  |
 
-## 🙌 Contribute
+## 🤝 Contribute
 
-Contributions are welcome, including new counting rules, accuracy improvements, tests, and documentation. See the [Ultralytics Contributing Guide](https://docs.ultralytics.com/help/contributing/) to get started.
+We thrive on community collaboration! THOP wouldn't be the tool it is without contributions from developers like you. Please see our [Contributing Guide](https://docs.ultralytics.com/help/contributing) to get started. We also welcome your feedback—share your experience by completing our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey). A huge **Thank You** 🙏 to everyone who contributes!
+
+<!-- SVG image from https://opencollective.com/ultralytics/contributors.svg?width=1280 -->
+
+[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/thop/graphs/contributors)
+
+We look forward to your contributions to help make the Ultralytics ecosystem even better!
 
 ## 📜 License
 
-THOP is distributed under the [AGPL-3.0 License](LICENSE). For commercial use, see the [Ultralytics Enterprise License](https://www.ultralytics.com/license).
+Ultralytics offers two licensing options to suit different needs:
 
-## 📧 Contact
+- **AGPL-3.0 License**: This [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license is perfect for students, researchers, and enthusiasts. It encourages open collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/thop/blob/main/LICENSE) file for full details.
+- **Ultralytics Enterprise License**: For development and production use, this license enables seamless integration of Ultralytics software and AI models into business products and services, including internal tools, automated workflows, and production deployments, bypassing the open-source requirements of AGPL-3.0. To get started, please contact us via [Ultralytics Licensing](https://www.ultralytics.com/license).
 
-Report bugs and request features through [GitHub Issues](https://github.com/ultralytics/thop/issues). For questions and community support, join [Ultralytics Discord](https://discord.com/invite/ultralytics).
+## 📞 Contact
+
+For bug reports and feature requests related to THOP, please visit [GitHub Issues](https://github.com/ultralytics/thop/issues). For questions, discussions, and community support, join our active communities on [Discord](https://discord.com/invite/ultralytics), [Reddit](https://www.reddit.com/r/ultralytics/), and the [Ultralytics Community Forums](https://community.ultralytics.com/). We're here to help with all things Ultralytics!
+
+<br>
+<div align="center">
+  <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="3%" alt="Ultralytics BiliBili"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
+</div>

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ print(f"Formatted MACs: {macs_readable}, Formatted Parameters: {params_readable}
 
 ## 📊 Results of Recent Models
 
-The following detection models were profiled at 640 × 640 from their fused architecture definitions. Install `ultralytics`, then run `python benchmark/evaluate_famous_models.py` to reproduce the table without downloading model weights. FLOPs are often approximated as twice the MAC count.
+The following detection models were profiled at 640 × 640 from their fused architecture definitions using `ultralytics==8.4.106`. Install that version, then run `python benchmark/evaluate_famous_models.py` to reproduce the table without downloading model weights. FLOPs are often approximated as twice the MAC count.
 
 | Model                                                                  | size<br><sup>(pixels)</sup> | params<br><sup>(M)</sup> | MACs<br><sup>(B)</sup> |
 | ---------------------------------------------------------------------- | --------------------------- | ------------------------ | ---------------------- |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,7 +61,7 @@ from thop import profile
 
 
 def count_silu(module, inputs, output):
-    """作为简单示例，将每个输出元素计为一次运算。."""
+    """Count one operation per output element as a simple example."""
     module.total_ops += output.numel()
 
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,7 +94,7 @@ print(f"Formatted MACs: {macs_readable}, Formatted Parameters: {params_readable}
 
 ## 📊 近期模型结果
 
-下列目标检测模型使用融合后的架构定义和 640 × 640 输入进行分析。安装 `ultralytics` 后，运行 `python benchmark/evaluate_famous_models.py` 即可复现此表，无需下载模型权重。FLOPs 通常可近似为 MACs 的两倍。
+下列目标检测模型使用 `ultralytics==8.4.106` 中融合后的架构定义和 640 × 640 输入进行分析。安装该版本后，运行 `python benchmark/evaluate_famous_models.py` 即可复现此表，无需下载模型权重。FLOPs 通常可近似为 MACs 的两倍。
 
 | 模型                                                                   | 尺寸<br><sup>(像素)</sup> | 参数<br><sup>(百万)</sup> | MACs<br><sup>(十亿)</sup> |
 | ---------------------------------------------------------------------- | ------------------------- | ------------------------- | ------------------------- |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,20 +2,20 @@
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-# 🚀 THOP: PyTorch-OpCounter
+# 🚀 THOP：PyTorch 运算量分析工具
 
-[THOP](https://github.com/ultralytics/thop) profiles [PyTorch](https://pytorch.org/) models by counting Multiply-Accumulate Operations (MACs) and parameters. It is lightweight, easy to extend, and maintained by [Ultralytics](https://www.ultralytics.com/).
+[THOP](https://github.com/ultralytics/thop) 用于分析 [PyTorch](https://pytorch.org/) 模型的乘加运算次数（MACs）和参数量。它轻量、易扩展，并由 [Ultralytics](https://www.ultralytics.com/) 维护。
 
 [![Ultralytics Actions](https://github.com/ultralytics/thop/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/thop/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
 [![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
 
-## 📄 Description
+## 📄 简介
 
-THOP measures a model with one forward pass, making it useful for comparing architecture complexity before training or deployment. It includes counting rules for common convolutional, normalization, pooling, activation, linear, and recurrent layers, with support for custom rules.
+THOP 通过一次前向传播测量模型，适合在训练或部署前比较不同架构的复杂度。它为常见的卷积、归一化、池化、激活、线性和循环层提供计数规则，也支持自定义规则。
 
-## 📦 Installation
+## 📦 安装
 
 [![PyPI - Version](https://img.shields.io/pypi/v/ultralytics-thop?logo=pypi&logoColor=white)](https://pypi.org/project/ultralytics-thop/) [![Downloads](https://static.pepy.tech/badge/ultralytics-thop)](https://clickpy.clickhouse.com/dashboard/ultralytics-thop) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ultralytics-thop?logo=python&logoColor=gold)](https://pypi.org/project/ultralytics-thop/)
 
@@ -23,17 +23,17 @@ THOP measures a model with one forward pass, making it useful for comparing arch
 pip install ultralytics-thop
 ```
 
-To install the latest development version:
+安装最新开发版本：
 
 ```bash
 pip install --upgrade git+https://github.com/ultralytics/thop.git
 ```
 
-## 🛠️ How to Use
+## 🛠️ 使用方法
 
-### Basic Usage
+### 基本用法
 
-Pass the model and a tuple of example inputs to `profile()`:
+将模型和示例输入元组传给 `profile()`：
 
 ```python
 import torch
@@ -46,12 +46,12 @@ inputs = (torch.randn(1, 3, 224, 224),)
 macs, params = profile(model, inputs=inputs)
 
 print(f"MACs: {macs}, Parameters: {params}")
-# Expected output: MACs: 4133742592.0, Parameters: 25557032.0
+# 预期输出：MACs: 4133742592.0, Parameters: 25557032.0
 ```
 
-### Define Custom Rules for Third-Party Modules
+### 为第三方模块定义自定义规则
 
-Map an unsupported module type to a forward-hook function. The hook receives the module, its inputs, and its output, then adds the operation count to `module.total_ops`.
+将不受支持的模块类型映射到前向钩子函数。钩子函数接收模块、输入和输出，并将运算量累加到 `module.total_ops`。
 
 ```python
 import torch
@@ -61,7 +61,7 @@ from thop import profile
 
 
 def count_silu(module, inputs, output):
-    """Count one operation per output element as a simple example."""
+    """作为简单示例，将每个输出元素计为一次运算。"""
     module.total_ops += output.numel()
 
 
@@ -70,12 +70,12 @@ inputs = (torch.randn(1, 3, 224, 224),)
 macs, params = profile(model, inputs=inputs, custom_ops={nn.SiLU: count_silu})
 
 print(f"Custom MACs: {macs}, Parameters: {params}")
-# Expected output: Custom MACs: 89915392.0, Parameters: 1792.0
+# 预期输出：Custom MACs: 89915392.0, Parameters: 1792.0
 ```
 
-### Improve Output Readability
+### 提升输出可读性
 
-Use `clever_format()` to convert raw counts into human-readable values:
+使用 `clever_format()` 将原始计数转换为易读格式：
 
 ```python
 import torch
@@ -89,14 +89,14 @@ macs, params = profile(model, inputs=inputs)
 macs_readable, params_readable = clever_format([macs, params], "%.3f")
 
 print(f"Formatted MACs: {macs_readable}, Formatted Parameters: {params_readable}")
-# Expected output: Formatted MACs: 4.134G, Formatted Parameters: 25.557M
+# 预期输出：Formatted MACs: 4.134G, Formatted Parameters: 25.557M
 ```
 
-## 📊 Results of Recent Models
+## 📊 近期模型结果
 
-The following detection models were profiled at 640 × 640 from their fused architecture definitions. Install `ultralytics`, then run `python benchmark/evaluate_famous_models.py` to reproduce the table without downloading model weights. FLOPs are often approximated as twice the MAC count.
+下列目标检测模型使用融合后的架构定义和 640 × 640 输入进行分析。安装 `ultralytics` 后，运行 `python benchmark/evaluate_famous_models.py` 即可复现此表，无需下载模型权重。FLOPs 通常可近似为 MACs 的两倍。
 
-| Model                                                  | Params (M) | MACs (G) |
+| 模型                                                   | 参数量 (M) | MACs (G) |
 | ------------------------------------------------------ | ---------- | -------- |
 | [YOLOv8n](https://docs.ultralytics.com/models/yolov8/) | 3.15       | 4.37     |
 | YOLOv8s                                                | 11.16      | 14.30    |
@@ -114,14 +114,14 @@ The following detection models were profiled at 640 × 640 from their fused arch
 | YOLO26l                                                | 24.81      | 43.22    |
 | YOLO26x                                                | 55.73      | 96.94    |
 
-## 🙌 Contribute
+## 🙌 贡献
 
-Contributions are welcome, including new counting rules, accuracy improvements, tests, and documentation. See the [Ultralytics Contributing Guide](https://docs.ultralytics.com/help/contributing/) to get started.
+欢迎贡献新的计数规则、精度改进、测试和文档。请参阅 [Ultralytics 贡献指南](https://docs.ultralytics.com/help/contributing/)开始参与。
 
-## 📜 License
+## 📜 许可证
 
-THOP is distributed under the [AGPL-3.0 License](LICENSE). For commercial use, see the [Ultralytics Enterprise License](https://www.ultralytics.com/license).
+THOP 采用 [AGPL-3.0 许可证](LICENSE)发布。如需商业使用，请参阅 [Ultralytics 企业许可证](https://www.ultralytics.com/license)。
 
-## 📧 Contact
+## 📧 联系方式
 
-Report bugs and request features through [GitHub Issues](https://github.com/ultralytics/thop/issues). For questions and community support, join [Ultralytics Discord](https://discord.com/invite/ultralytics).
+请通过 [GitHub Issues](https://github.com/ultralytics/thop/issues) 报告错误或提出功能建议。如需提问和社区支持，请加入 [Ultralytics Discord](https://discord.com/invite/ultralytics)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,32 +96,58 @@ print(f"Formatted MACs: {macs_readable}, Formatted Parameters: {params_readable}
 
 下列目标检测模型使用融合后的架构定义和 640 × 640 输入进行分析。安装 `ultralytics` 后，运行 `python benchmark/evaluate_famous_models.py` 即可复现此表，无需下载模型权重。FLOPs 通常可近似为 MACs 的两倍。
 
-| 模型                                                   | 参数量 (M) | MACs (G) |
-| ------------------------------------------------------ | ---------- | -------- |
-| [YOLOv8n](https://docs.ultralytics.com/models/yolov8/) | 3.15       | 4.37     |
-| YOLOv8s                                                | 11.16      | 14.30    |
-| YOLOv8m                                                | 25.89      | 39.47    |
-| YOLOv8l                                                | 43.67      | 82.58    |
-| YOLOv8x                                                | 68.20      | 128.91   |
-| [YOLO11n](https://docs.ultralytics.com/models/yolo11/) | 2.62       | 3.24     |
-| YOLO11s                                                | 9.44       | 10.74    |
-| YOLO11m                                                | 20.09      | 33.99    |
-| YOLO11l                                                | 25.34      | 43.46    |
-| YOLO11x                                                | 56.92      | 97.46    |
-| [YOLO26n](https://docs.ultralytics.com/models/yolo26/) | 2.41       | 2.68     |
-| YOLO26s                                                | 9.50       | 10.35    |
-| YOLO26m                                                | 20.41      | 34.09    |
-| YOLO26l                                                | 24.81      | 43.22    |
-| YOLO26x                                                | 55.73      | 96.94    |
+| 模型                                                                   | 尺寸<br><sup>(像素)</sup> | 参数<br><sup>(百万)</sup> | MACs<br><sup>(十亿)</sup> |
+| ---------------------------------------------------------------------- | ------------------------- | ------------------------- | ------------------------- |
+| [YOLOv8n](https://platform.ultralytics.com/ultralytics/yolov8/yolov8n) | 640                       | 3.15                      | 4.37                      |
+| [YOLOv8s](https://platform.ultralytics.com/ultralytics/yolov8/yolov8s) | 640                       | 11.16                     | 14.30                     |
+| [YOLOv8m](https://platform.ultralytics.com/ultralytics/yolov8/yolov8m) | 640                       | 25.89                     | 39.47                     |
+| [YOLOv8l](https://platform.ultralytics.com/ultralytics/yolov8/yolov8l) | 640                       | 43.67                     | 82.58                     |
+| [YOLOv8x](https://platform.ultralytics.com/ultralytics/yolov8/yolov8x) | 640                       | 68.20                     | 128.91                    |
+| [YOLO11n](https://platform.ultralytics.com/ultralytics/yolo11/yolo11n) | 640                       | 2.62                      | 3.24                      |
+| [YOLO11s](https://platform.ultralytics.com/ultralytics/yolo11/yolo11s) | 640                       | 9.44                      | 10.74                     |
+| [YOLO11m](https://platform.ultralytics.com/ultralytics/yolo11/yolo11m) | 640                       | 20.09                     | 33.99                     |
+| [YOLO11l](https://platform.ultralytics.com/ultralytics/yolo11/yolo11l) | 640                       | 25.34                     | 43.46                     |
+| [YOLO11x](https://platform.ultralytics.com/ultralytics/yolo11/yolo11x) | 640                       | 56.92                     | 97.46                     |
+| [YOLO26n](https://platform.ultralytics.com/ultralytics/yolo26/yolo26n) | 640                       | 2.41                      | 2.68                      |
+| [YOLO26s](https://platform.ultralytics.com/ultralytics/yolo26/yolo26s) | 640                       | 9.50                      | 10.35                     |
+| [YOLO26m](https://platform.ultralytics.com/ultralytics/yolo26/yolo26m) | 640                       | 20.41                     | 34.09                     |
+| [YOLO26l](https://platform.ultralytics.com/ultralytics/yolo26/yolo26l) | 640                       | 24.81                     | 43.22                     |
+| [YOLO26x](https://platform.ultralytics.com/ultralytics/yolo26/yolo26x) | 640                       | 55.73                     | 96.94                     |
 
-## 🙌 贡献
+## 🤝 贡献
 
-欢迎贡献新的计数规则、精度改进、测试和文档。请参阅 [Ultralytics 贡献指南](https://docs.ultralytics.com/help/contributing/)开始参与。
+我们依靠社区协作蓬勃发展！没有像您这样的开发者的贡献，THOP 就不会成为如今优秀的工具。请参阅我们的[贡献指南](https://docs.ultralytics.com/help/contributing)开始贡献。我们也欢迎您的反馈——通过完成我们的[调查问卷](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey)分享您的体验。非常**感谢** 🙏 每一位贡献者！
+
+<!-- SVG image from https://opencollective.com/ultralytics/contributors.svg?width=1280 -->
+
+[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/thop/graphs/contributors)
+
+我们期待您的贡献，帮助 Ultralytics 生态系统变得更好！
 
 ## 📜 许可证
 
-THOP 采用 [AGPL-3.0 许可证](LICENSE)发布。如需商业使用，请参阅 [Ultralytics 企业许可证](https://www.ultralytics.com/license)。
+Ultralytics 提供两种许可选项以满足不同需求：
 
-## 📧 联系方式
+- **AGPL-3.0 许可证**：这种经 [OSI 批准](https://opensource.org/license/agpl-3.0)的开源许可证非常适合学生、研究人员和爱好者。它鼓励开放协作和知识共享。有关完整详细信息，请参阅 [LICENSE](https://github.com/ultralytics/thop/blob/main/LICENSE) 文件。
+- **Ultralytics 企业许可证**：适用于开发和生产用途，此许可证允许将 Ultralytics 软件和 AI 模型无缝集成到业务产品和服务中，包括内部工具、自动化工作流和生产部署，绕过 AGPL-3.0 的开源要求。如需开始使用，请通过 [Ultralytics 授权许可](https://www.ultralytics.com/license)与我们联系。
 
-请通过 [GitHub Issues](https://github.com/ultralytics/thop/issues) 报告错误或提出功能建议。如需提问和社区支持，请加入 [Ultralytics Discord](https://discord.com/invite/ultralytics)。
+## 📞 联系方式
+
+有关 THOP 的错误报告和功能请求，请访问 [GitHub Issues](https://github.com/ultralytics/thop/issues)。如有疑问、讨论和社区支持，请加入我们在 [Discord](https://discord.com/invite/ultralytics)、[Reddit](https://www.reddit.com/r/ultralytics/) 和 [Ultralytics 社区论坛](https://community.ultralytics.com/)上的活跃社区。我们随时为您提供有关 Ultralytics 的所有帮助！
+
+<br>
+<div align="center">
+  <a href="https://github.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-github.png" width="3%" alt="Ultralytics GitHub"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.linkedin.com/company/ultralytics/"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-linkedin.png" width="3%" alt="Ultralytics LinkedIn"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://ultralytics.com/bilibili"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-bilibili.png" width="3%" alt="Ultralytics BiliBili"></a>
+  <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
+  <a href="https://discord.com/invite/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-discord.png" width="3%" alt="Ultralytics Discord"></a>
+</div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,7 +61,7 @@ from thop import profile
 
 
 def count_silu(module, inputs, output):
-    """作为简单示例，将每个输出元素计为一次运算。"""
+    """作为简单示例，将每个输出元素计为一次运算。."""
     module.total_ops += output.numel()
 
 

--- a/benchmark/evaluate_famous_models.py
+++ b/benchmark/evaluate_famous_models.py
@@ -1,30 +1,18 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-from torchvision import models
+from ultralytics import YOLO
 
-from thop.profile import profile
+from thop import profile
 
-model_names = sorted(
-    name
-    for name in models.__dict__
-    if name.islower()
-    and not name.startswith("__")  # and "inception" in name
-    and callable(models.__dict__[name])
-)
+model_names = [f"{family}{size}" for family in ("yolov8", "yolo11", "yolo26") for size in "nsmlx"]
 
-print("Model | Params(M) | FLOPs(G)")
+print("Model | Params(M) | MACs(G)")
 print("---|---|---")
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 for name in model_names:
-    try:
-        model = models.__dict__[name]().to(device)
-        dsize = (1, 3, 224, 224)
-        if "inception" in name:
-            dsize = (1, 3, 299, 299)
-        inputs = torch.randn(dsize).to(device)
-        total_ops, total_params = profile(model, (inputs,), verbose=False)
-        print(f"{name} | {total_params / (1000**2):.2f} | {total_ops / (1000**3):.2f}")
-    except Exception as e:
-        print(f"Warning: failed to process {e}")
+    model = YOLO(f"{name}.yaml").model.fuse(verbose=False).to(device)
+    inputs = torch.zeros(1, 3, 640, 640, device=device)
+    total_ops, total_params = profile(model, (inputs,), verbose=False)
+    print(f"{name} | {total_params / 1e6:.2f} | {total_ops / 1e9:.2f}")

--- a/benchmark/evaluate_famous_models.py
+++ b/benchmark/evaluate_famous_models.py
@@ -1,9 +1,13 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import torch
-from ultralytics import YOLO
+from ultralytics import YOLO, __version__
 
 from thop import profile
+
+ULTRALYTICS_VERSION = "8.4.106"
+if __version__ != ULTRALYTICS_VERSION:
+    raise RuntimeError(f"Install ultralytics=={ULTRALYTICS_VERSION} to reproduce these benchmarks.")
 
 model_names = [f"{family}{size}" for family in ("yolov8", "yolo11", "yolo26") for size in "nsmlx"]
 


### PR DESCRIPTION
## Summary
- replace legacy torchvision benchmark tables with fused YOLOv8, YOLO11, and YOLO26 results
- update the benchmark generator to reproduce all 15 model variants without downloading weights
- simplify the README examples and add a Simplified Chinese translation

## Validation
- `python -m pytest tests/` (19 passed)
- `python benchmark/evaluate_famous_models.py`
- README benchmark-table consistency check
- all Python snippets from both README files
- `ruff check .`
- `ruff format --check --line-length 120 .`
- `npx prettier --check --print-width 120 README.md README.zh-CN.md`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📚 Modernized the THOP documentation and benchmarking workflow, adding Chinese language support and updated YOLOv8, YOLO11, and YOLO26 profiling results.

### 📊 Key Changes

- Added a bilingual README with a new [Simplified Chinese translation](README.zh-CN.md).
- Simplified and clarified the English documentation for:
  - Installation and development setup.
  - Basic `profile()` usage.
  - Custom operation-counting rules.
  - Human-readable output formatting with `clever_format()`.
- Replaced the outdated torchvision model benchmark table with detection-model benchmarks for:
  - YOLOv8
  - YOLO11
  - YOLO26
- Updated `benchmark/evaluate_famous_models.py` to:
  - Use Ultralytics model definitions instead of torchvision models.
  - Profile fused models at 640 × 640 resolution.
  - Validate `ultralytics==8.4.106` for reproducible results.
  - Report MACs and parameter counts without downloading model weights.
- Refreshed contribution, licensing, contact, and community-support sections.

### 🎯 Purpose & Impact

- ✅ Makes THOP easier to understand and use for both new and experienced developers.
- 🌏 Expands accessibility for Chinese-speaking users through localized documentation.
- 📊 Provides more relevant complexity comparisons for current Ultralytics detection models, including the recommended YOLO26 family.
- 🔁 Improves benchmark reproducibility by pinning the Ultralytics version and documenting the exact input size and workflow.
- 🧩 Clarifies how to extend THOP for unsupported third-party PyTorch modules.
- ⚠️ Benchmark results now specifically represent fused YOLO architectures at 640 × 640, so they should not be directly compared with the previous torchvision results measured at different input sizes.