### PR TITLE
Format an exact power of 1000 and a negative value in the right unit

### DIFF
--- a/thop/utils.py
+++ b/thop/utils.py
@@ -30,14 +30,12 @@ def clever_format(nums, format="%.2f"):
     clever_nums = []
 
     for num in nums:
-        if num > 1e12:
-            clever_nums.append(format % (num / 1e12) + "T")
-        elif num > 1e9:
-            clever_nums.append(format % (num / 1e9) + "G")
-        elif num > 1e6:
-            clever_nums.append(format % (num / 1e6) + "M")
-        elif num > 1e3:
-            clever_nums.append(format % (num / 1e3) + "K")
+        for unit, scale in (("T", 1e12), ("G", 1e9), ("M", 1e6), ("K", 1e3)):
+            # abs() and >=, not the value against >: a negative satisfied no comparison and came out unscaled,
+            # and an exact power of 1000 belongs to the unit it is one of rather than to the one below it
+            if abs(num) >= scale:
+                clever_nums.append(format % (num / scale) + unit)
+                break
         else:
             clever_nums.append(format % num + "B")
 


### PR DESCRIPTION
## What

`clever_format` compared each value against `> 1e12`, `> 1e9`, `> 1e6`, `> 1e3`. Neither boundary case that follows from those comparisons is what the function means to print: an exact power of 1000 fails its own test and formats in the unit below, and a negative satisfies no comparison at all and comes back unscaled.

| input   | before            | after    |
| ------- | ----------------- | -------- |
| `1000`  | `1000.00B`        | `1.00K`  |
| `1e6`   | `1000.00K`        | `1.00M`  |
| `1e9`   | `1000.00M`        | `1.00G`  |
| `1e12`  | `1000.00G`        | `1.00T`  |
| `-1e9`  | `-1000000000.00B` | `-1.00G` |
| `-1234` | `-1234.00B`       | `-1.23K` |

Comparing `abs(num)` against `>=` fixes both, and one loop over the four units replaces the four-branch chain, so the threshold and its unit are written once each instead of twice.

## What does not move

The `"B"` a value below 1000 still gets, which is neither bytes nor billions. `tests/test_utils.py:13` and `:20` assert that string, so dropping it means rewriting committed expectations — a decision about what the function should print rather than a fix. Every unit-less string is unchanged: `1` → `1.00B`, `999` → `999.00B`, `-5` → `-5.00B`, `0` → `0.00B`.

`clever_format` is rendered in two places, both checked: `tests/test_utils.py` passes untouched, and the README example prints its documented literals byte for byte, `Formatted MACs: 4.134G, Formatted Parameters: 25.557M`. The README benchmark table does not go through this function.

## Deleted

The four-branch comparison chain, with its eight repeated literals. 6 insertions against 8 deletions.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves `clever_format` to correctly format negative values and exact unit boundaries. 🔢

### 📊 Key Changes

- Reworked unit selection using a loop for tera, giga, mega, and kilo scales.
- Uses `abs(num) >= scale` to support negative values and include exact thresholds.
- Ensures values such as `1,000` format as `1.00K` rather than `1000.00B`.
- Preserves existing formatting for values below 1,000 by displaying them in bytes (`B`).

### 🎯 Purpose & Impact

- ✅ Produces more accurate and intuitive human-readable metric values.
- 📈 Correctly formats both positive and negative numbers across all supported units.
- 🛠️ Fixes boundary cases at powers of 1,000 without changing the public API.
- 🌍 Improves reliability for THOP users inspecting model complexity metrics such as parameters, FLOPs, or operation counts.