### PR TITLE
Run the test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# THOP Continuous Integration (CI) GitHub Actions tests
+
+name: CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request: # unfiltered, as ultralytics/ultralytics is: a pull request stacked on a feature branch runs too
+  schedule:
+    - cron: "0 9 * * *" # runs at 09:00 UTC every day, so a torch release that breaks counting shows up here first
+  workflow_dispatch:
+
+jobs:
+  Tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.14"]
+        torch: [latest]
+        include:
+          - python: "3.8" # the requires-python floor; torch 1.8.0 requires python >=3.6, <=3.9
+            torch: "1.8.0"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ultralytics/actions/setup-uv@main
+        with:
+          python-version: ${{ matrix.python }}
+          activate-environment: true
+      - name: Install requirements
+        run: |
+          torch=""
+          if [ "${{ matrix.torch }}" != "latest" ]; then
+              torch="torch==${{ matrix.torch }}"
+          fi
+          uv pip install -e . $torch pytest --torch-backend cpu
+      - name: Run tests
+        run: python -m pytest tests -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ ruff format --line-length 120 .
 npx prettier --write --print-width 120 "**/*.{yml,yaml,json,md}"
 ```
 
-- `ci.yml` runs `tests/` on every push and pull request and nightly, at the `requires-python` floor (Python 3.8 with torch 1.8.0) and at the ceiling (3.14, latest torch) — run them locally before pushing all the same. Coverage is not measured, and `publish.yml` (PyPI release) is gated on the version bump alone, so a release does not imply a green suite; the other workflows are `format.yml` (autoformat + AI labels/summaries on PRs) and `cla.yml` (CLA signing).
+- `ci.yml` runs `tests/` on every pull request, on pushes to `main`, and nightly, at the `requires-python` floor (Python 3.8 with torch 1.8.0) and at the ceiling (3.14, latest torch) — run them locally before pushing all the same. Coverage is not measured, and `publish.yml` (PyPI release) is gated on the version bump alone, so a release does not imply a green suite; the other workflows are `format.yml` (autoformat + AI labels/summaries on PRs) and `cla.yml` (CLA signing).
 - `requires-python = ">=3.8"` in pyproject.toml; classifiers cover Python 3.8–3.14. The `--target-version py39` above intentionally matches CI (ultralytics/actions uses py39 for pyupgrade), so don't accept pyupgrade fixes that would break Python 3.8 syntax support.
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ ruff format --line-length 120 .
 npx prettier --write --print-width 120 "**/*.{yml,yaml,json,md}"
 ```
 
-- There is no test or coverage CI: the only workflows are `format.yml` (autoformat + AI labels/summaries on PRs), `cla.yml` (CLA signing), and `publish.yml` (PyPI release) — run tests locally before pushing.
+- `ci.yml` runs `tests/` on every push and pull request and nightly, at the `requires-python` floor (Python 3.8 with torch 1.8.0) and at the ceiling (3.14, latest torch) — run them locally before pushing all the same. Coverage is not measured, and `publish.yml` (PyPI release) is gated on the version bump alone, so a release does not imply a green suite; the other workflows are `format.yml` (autoformat + AI labels/summaries on PRs) and `cla.yml` (CLA signing).
 - `requires-python = ">=3.8"` in pyproject.toml; classifiers cover Python 3.8–3.14. The `--target-version py39` above intentionally matches CI (ultralytics/actions uses py39 for pyupgrade), so don't accept pyupgrade fixes that would break Python 3.8 syntax support.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [THOP](https://github.com/ultralytics/thop) profiles [PyTorch](https://pytorch.org/) models by counting Multiply-Accumulate Operations (MACs) and parameters. It is lightweight, easy to extend, and maintained by [Ultralytics](https://www.ultralytics.com/).
 
+[![THOP CI](https://github.com/ultralytics/thop/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/thop/actions/workflows/ci.yml)
 [![Ultralytics Actions](https://github.com/ultralytics/thop/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/thop/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,7 @@
 
 [THOP](https://github.com/ultralytics/thop) 用于分析 [PyTorch](https://pytorch.org/) 模型的乘加运算次数（MACs）和参数量。它轻量、易扩展，并由 [Ultralytics](https://www.ultralytics.com/) 维护。
 
+[![THOP CI](https://github.com/ultralytics/thop/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/thop/actions/workflows/ci.yml)
 [![Ultralytics Actions](https://github.com/ultralytics/thop/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/thop/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)


### PR DESCRIPTION
## summary

thop ships 19 tests and no workflow that runs them, so a pull request touching a covered function merges on a green board without those tests ever executing. this adds `ci.yml`, running `pytest tests` on push, pull request and nightly at the `requires-python` floor (python 3.8 with torch 1.8.0) and at the ceiling (3.14, latest torch), following the same matrix and install form as ultralytics/actions and ultralytics/ultralytics.

the `pull_request` trigger is unfiltered, as it is in ultralytics/ultralytics, so a pull request stacked on a feature branch runs the checks too. the AGENTS.md line describing the repository as having no test CI is updated, and both READMEs get the badge.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚦 Adds automated CI testing for THOP across supported Python and PyTorch versions, improving release confidence and project visibility.

### 📊 Key Changes

- Added a GitHub Actions CI workflow that:
  - Runs on pull requests, pushes to `main`, nightly, and manual triggers.
  - Tests Python 3.8 with PyTorch 1.8.0 and Python 3.14 with the latest PyTorch.
  - Installs dependencies with `uv` and runs the full `tests/` suite using `pytest`.
- Updated `AGENTS.md` with the new CI coverage, supported version range, and workflow details.
- Added CI status badges to both the English and Chinese README files.

### 🎯 Purpose & Impact

- 🛡️ Detects regressions and compatibility issues earlier, including problems introduced by new PyTorch releases.
- 🔄 Verifies THOP at both the minimum supported environment and the latest supported environment.
- 🤝 Gives contributors immediate feedback on pull requests and helps maintain code quality.
- 👀 Makes CI status visible to users through the project README files.