### PR TITLE
Read the axes each layer owns and charge the average pool window

### DIFF
--- a/thop/rnn_hooks.py
+++ b/thop/rnn_hooks.py
@@ -5,6 +5,19 @@ from torch import nn
 from torch.nn.utils.rnn import PackedSequence
 
 
+def _batch_and_steps(m, x):
+    """Return the batch size and the number of time steps a recurrent layer's input carries.
+
+    torch has accepted unbatched input since 1.9, as a (L, H_in) sequence with no batch axis at all, and it ignores
+    batch_first for it. Reading an axis by position would take the sequence length for a batch there.
+    """
+    if isinstance(x, PackedSequence):
+        return torch.max(x.batch_sizes), x.batch_sizes.size(0)
+    if x.dim() == 2:
+        return 1, x.size(0)
+    return (x.size(0), x.size(1)) if m.batch_first else (x.size(1), x.size(0))
+
+
 def _count_rnn_cell(input_size, hidden_size, bias=True):
     """Calculate the total operations for an RNN cell given input size, hidden size, and optional bias."""
     total_ops = hidden_size * (input_size + hidden_size) + hidden_size
@@ -18,8 +31,8 @@ def count_rnn_cell(m: nn.RNNCell, x: torch.Tensor, y: torch.Tensor):
     """Counts the total RNN cell operations based on input tensor, hidden size, bias, and batch size."""
     total_ops = _count_rnn_cell(m.input_size, m.hidden_size, m.bias)
 
-    batch_size = x[0].size(0)
-    total_ops *= batch_size
+    # a cell takes one vector per batch entry, so a 1-dimensional input is a single unbatched sample
+    total_ops *= x[0].size(0) if x[0].dim() == 2 else 1
 
     m.total_ops += int(total_ops)
 
@@ -52,8 +65,8 @@ def count_gru_cell(m: nn.GRUCell, x: torch.Tensor, y: torch.Tensor):
     """Calculates and updates the total operations for a GRU cell in a mini-batch during inference."""
     total_ops = _count_gru_cell(m.input_size, m.hidden_size, m.bias)
 
-    batch_size = x[0].size(0)
-    total_ops *= batch_size
+    # a cell takes one vector per batch entry, so a 1-dimensional input is a single unbatched sample
+    total_ops *= x[0].size(0) if x[0].dim() == 2 else 1
 
     m.total_ops += int(total_ops)
 
@@ -85,8 +98,8 @@ def count_lstm_cell(m: nn.LSTMCell, x: torch.Tensor, y: torch.Tensor):
     """Counts and updates the total operations for an LSTM cell in a mini-batch during inference."""
     total_ops = _count_lstm_cell(m.input_size, m.hidden_size, m.bias)
 
-    batch_size = x[0].size(0)
-    total_ops *= batch_size
+    # a cell takes one vector per batch entry, so a 1-dimensional input is a single unbatched sample
+    total_ops *= x[0].size(0) if x[0].dim() == 2 else 1
 
     m.total_ops += int(total_ops)
 
@@ -98,15 +111,7 @@ def count_rnn(m: nn.RNN, x, y):
     hidden_size = m.hidden_size
     num_layers = m.num_layers
 
-    if isinstance(x[0], PackedSequence):
-        batch_size = torch.max(x[0].batch_sizes)
-        num_steps = x[0].batch_sizes.size(0)
-    elif m.batch_first:
-        batch_size = x[0].size(0)
-        num_steps = x[0].size(1)
-    else:
-        batch_size = x[0].size(1)
-        num_steps = x[0].size(0)
+    batch_size, num_steps = _batch_and_steps(m, x[0])
 
     total_ops = 0
     if m.bidirectional:
@@ -135,15 +140,7 @@ def count_gru(m: nn.GRU, x, y):
     hidden_size = m.hidden_size
     num_layers = m.num_layers
 
-    if isinstance(x[0], PackedSequence):
-        batch_size = torch.max(x[0].batch_sizes)
-        num_steps = x[0].batch_sizes.size(0)
-    elif m.batch_first:
-        batch_size = x[0].size(0)
-        num_steps = x[0].size(1)
-    else:
-        batch_size = x[0].size(1)
-        num_steps = x[0].size(0)
+    batch_size, num_steps = _batch_and_steps(m, x[0])
 
     total_ops = 0
     if m.bidirectional:
@@ -172,15 +169,7 @@ def count_lstm(m: nn.LSTM, x, y):
     hidden_size = m.hidden_size
     num_layers = m.num_layers
 
-    if isinstance(x[0], PackedSequence):
-        batch_size = torch.max(x[0].batch_sizes)
-        num_steps = x[0].batch_sizes.size(0)
-    elif m.batch_first:
-        batch_size = x[0].size(0)
-        num_steps = x[0].size(1)
-    else:
-        batch_size = x[0].size(1)
-        num_steps = x[0].size(0)
+    batch_size, num_steps = _batch_and_steps(m, x[0])
 
     total_ops = 0
     if m.bidirectional:

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -114,9 +114,7 @@ def count_avgpool(m, x, y):
     windows = 1
     for size, output, k, s, p in zip(x[0].shape[-dims:], y.shape[-dims:], kernel, stride, padding):
         lower, upper = (-p, size + p) if m.count_include_pad else (0, size)
-        windows *= sum(
-            max(min(i * s - p + k, upper) - max(i * s - p, lower), 0) for i in range(output)
-        )
+        windows *= sum(max(min(i * s - p + k, upper) - max(i * s - p, lower), 0) for i in range(output))
     m.total_ops += l_prod(x[0].shape[:-dims]) * windows + y.numel()  # one add per input, one divide per output
 
 

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -7,7 +7,6 @@ from torch import nn
 from torch.nn.modules.conv import _ConvNd
 
 from thop.vision.calc_func import (
-    calculate_avgpool,
     calculate_conv2d_flops,
     calculate_linear,
     calculate_norm,
@@ -105,11 +104,13 @@ def count_softmax(m, x, y):
 
 
 def count_avgpool(m, x, y):
-    """Calculate and update the total number of operations (FLOPs) for an AvgPool layer based on the output elements."""
-    # total_div = 1
-    # kernel_ops = total_add + total_div
-    num_elements = y.numel()
-    m.total_ops += calculate_avgpool(num_elements)
+    """Calculate and update the total operation counts for an AvgPool layer from the window it averages."""
+    kernel = m.kernel_size
+    if isinstance(kernel, int):  # only AvgPool2d and AvgPool3d keep it as passed, AvgPool1d normalizes to a tuple
+        kernel = (kernel,) * (3 if isinstance(m, nn.AvgPool3d) else 2)
+    # One add per pooled input and one divide per output, as count_adap_avgpool already charges. The output
+    # element count this replaced ignored the window, so every kernel size cost the same.
+    m.total_ops += (l_prod(kernel) + 1) * y.numel()
 
 
 def count_adap_avgpool(m, x, y):
@@ -117,12 +118,17 @@ def count_adap_avgpool(m, x, y):
     # the windows nn.AdaptiveAvgPool* actually slices, per dimension: output j spans
     # [j * I // O, ceil((j + 1) * I / O)), so their sizes are integral and unequal whenever O does not divide I.
     # The input-over-output ratio this replaced was a float, which made total_ops fractional, and it was also
-    # smaller than the window it stood for
-    windows = l_prod(
-        sum(-(-(j + 1) * i // o) - j * i // o for j in range(o)) for i, o in zip(x[0].shape[2:], y.shape[2:])
-    )
-    num_elements = y.numel()
-    m.total_ops += windows * (num_elements // l_prod(y.shape[2:])) + num_elements  # one add per input, one divide out
+    # smaller than the window it stood for.
+    # Every axis is walked, not only the pooled ones: an axis the layer leaves alone has one input per output, so
+    # it contributes its own length and the batch and channel counts fall out of the same product. That is what
+    # the pooled-axes slice had to multiply back by hand, and it needs no batch axis to be there to slice off.
+    m.total_ops += (
+        l_prod(
+            o if i == o else sum(-(-(j + 1) * i // o) - j * i // o for j in range(o))
+            for i, o in zip(x[0].shape, y.shape)
+        )
+        + y.numel()
+    )  # one add per pooled input, one divide per output
 
 
 # TODO: verify the accuracy

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -104,13 +104,20 @@ def count_softmax(m, x, y):
 
 
 def count_avgpool(m, x, y):
-    """Calculate and update the total operation counts for an AvgPool layer from the window it averages."""
+    """Calculate and update the total operation count for an AvgPool layer."""
     kernel = m.kernel_size
     if isinstance(kernel, int):  # only AvgPool2d and AvgPool3d keep it as passed, AvgPool1d normalizes to a tuple
         kernel = (kernel,) * (3 if isinstance(m, nn.AvgPool3d) else 2)
-    # One add per pooled input and one divide per output, as count_adap_avgpool already charges. The output
-    # element count this replaced ignored the window, so every kernel size cost the same.
-    m.total_ops += (l_prod(kernel) + 1) * y.numel()
+    dims = len(kernel)
+    stride = (m.stride,) * dims if isinstance(m.stride, int) else m.stride
+    padding = (m.padding,) * dims if isinstance(m.padding, int) else m.padding
+    windows = 1
+    for size, output, k, s, p in zip(x[0].shape[-dims:], y.shape[-dims:], kernel, stride, padding):
+        lower, upper = (-p, size + p) if m.count_include_pad else (0, size)
+        windows *= sum(
+            max(min(i * s - p + k, upper) - max(i * s - p, lower), 0) for i in range(output)
+        )
+    m.total_ops += l_prod(x[0].shape[:-dims]) * windows + y.numel()  # one add per input, one divide per output
 
 
 def count_adap_avgpool(m, x, y):

--- a/thop/vision/calc_func.py
+++ b/thop/vision/calc_func.py
@@ -27,15 +27,11 @@ def calculate_zero_ops():
 def calculate_conv2d_flops(
     input_size: list, output_size: list, kernel_size: list, groups: int, bias: bool = False, transpose: bool = False
 ):
-    """Calculate FLOPs for a Conv2D layer using input/output sizes, kernel size, groups, and the bias flag."""
-    # n, in_c, ih, iw = input_size
-    # out_c, in_c, kh, kw = kernel_size
-    if transpose:
-        out_c = output_size[1]
-        return l_prod(input_size) * (out_c // groups) * l_prod(kernel_size[2:])
-    else:
-        in_c = input_size[1]
-        return l_prod(output_size) * (in_c // groups) * l_prod(kernel_size[2:])
+    """Calculate FLOPs for a ConvNd layer using input/output sizes, kernel size, groups, and the bias flag."""
+    # A transpose scatters rather than gathers, so it walks the input and takes its channel from the output.
+    volume, channels = (input_size, output_size) if transpose else (output_size, input_size)
+    # The channel axis is counted from the trailing end, so unbatched input lands on it too.
+    return l_prod(volume) * (channels[-(len(kernel_size) - 1)] // groups) * l_prod(kernel_size[2:])
 
 
 def calculate_norm(input_size):
@@ -50,11 +46,6 @@ def calculate_softmax(batch_size, nfeatures):
     total_div = nfeatures
     total_ops = batch_size * (total_exp + total_add + total_div)
     return int(total_ops)
-
-
-def calculate_avgpool(input_size):
-    """Calculate the average pooling size for a given input tensor."""
-    return int(input_size)
 
 
 def calculate_linear(in_feature, num_elements):


### PR DESCRIPTION
## Summary

Corrects unbatched convolution and recurrent shapes, counts fixed and adaptive average-pooling windows, and deletes the unused `calculate_avgpool` identity wrapper.

Convolution channels are read from the trailing spatial rank, recurrent batch/step resolution is shared once, and adaptive pooling walks every owned axis. Fixed average pooling now sums the effective window widths from the input/output shapes and layer parameters, so padding, `ceil_mode`, and `count_include_pad` boundary windows are counted instead of assuming every output sees a full kernel.

## Verification

- The full test suite passes on Python 3.8/torch 1.8 and Python 3.14/latest torch in CI.
- 384 generated convolution/pooling cases and 78 recurrent configurations matched analytic ground truth before the boundary follow-up.
- `AvgPool1d(3, stride=2, ceil_mode=True, count_include_pad=False)` over length 4 now reports 7 operations for windows of lengths 3 and 2, rather than 8.
- `AvgPool2d(7)` and `AdaptiveAvgPool2d(1)` over `1x4x7x7` both report 200.
- README models remain unchanged except DenseNet-121, whose average-pooling correction moves 2,897,007,104 to 2,897,709,568 MACs (+0.024%).

The source diff remains net-negative.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧮 Improved THOP operation counting for unbatched, packed, recurrent, convolutional, and average-pooling layers.

### 📊 Key Changes
- Added shared RNN input-shape handling for:
  - Unbatched sequences.
  - `PackedSequence` inputs.
  - `batch_first=True` and standard layouts.
- Corrected RNN, GRU, and LSTM cell counting for unbatched inputs.
- Reworked average-pooling operation counting to account for:
  - Kernel size, stride, padding, and `count_include_pad`.
  - Actual pooling-window sizes at boundaries.
  - 1D, 2D, and 3D average-pooling layers.
- Improved adaptive average-pooling counts for uneven input/output dimensions and tensors without an explicit batch axis.
- Generalized convolution FLOP calculation for `ConvNd` layers and unbatched inputs, including transposed convolutions.
- Removed the obsolete `calculate_avgpool` helper.

### 🎯 Purpose & Impact
- ✅ Produces more accurate operation and FLOP estimates across a wider range of PyTorch layer configurations.
- 🧩 Prevents incorrect batch-size and sequence-length interpretation for unbatched and packed recurrent inputs.
- 🎯 Provides more realistic average-pooling counts, especially near padded edges and with uneven adaptive pooling.
- 🚀 Improves compatibility with 1D, 2D, and 3D convolutional and pooling models, making THOP profiling more reliable.