### PR TITLE
Preserve a caller-owned total_ops instead of colliding with it

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -109,10 +109,9 @@ def _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 def _displace_total_ops(m):
     """Temporarily remove a caller-owned `total_ops` attribute or buffer."""
     displaced = [(store, store["total_ops"]) for store in (m._buffers, m.__dict__) if "total_ops" in store]
-    if displaced:  # record first, remove second: nothing may run between taking the value and owning a copy
-        logging.warning(f"{m!s} already has a .total_ops; it is shadowed while profiling and restored after.")
-        for store, _ in displaced:
-            del store["total_ops"]
+    logging.warning(f"{m!s} already has a .total_ops; it is shadowed while profiling and restored after.")
+    for store, _ in displaced:
+        del store["total_ops"]
     return displaced
 
 
@@ -144,10 +143,7 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=
 
         if "total_ops" in m.__dict__ or "total_ops" in m._buffers:
             displaced_collection[m] = _displace_total_ops(m)
-        # register_buffer discards the name from _non_persistent_buffers_set, which is not one of the stores
-        # displaced above, so a buffer the caller deliberately kept out of its state_dict would come back inside
-        # it and fail a strict load. The membership goes back by hand rather than through persistent=, which a
-        # subclass overriding register_buffer with the older two-argument signature cannot accept.
+        # register_buffer discards this flag; restore it without requiring the newer persistent= argument.
         non_persistent = "total_ops" in m._non_persistent_buffers_set
         m.register_buffer("total_ops", torch.zeros(1, dtype=default_dtype))
         if non_persistent:
@@ -177,8 +173,8 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=
             handler.remove()
         for m in handler_collection:
             m._buffers.pop("total_ops", None)
-        for m, displaced in displaced_collection.items():  # only once this call's own buffer is gone: it
-            for store, value in displaced:  # holds the same key, and would otherwise shadow what goes back
+        for m, displaced in displaced_collection.items():
+            for store, value in displaced:
                 store["total_ops"] = value
         _restore_modes(prev_training)  # last: it calls train(), which is the caller's code and may raise
 
@@ -316,8 +312,8 @@ def profile(
             handler.remove()
         for m in handler_collection:
             m.__dict__.pop("total_ops", None)
-        for m, displaced in displaced_collection.items():  # only once this call's own counter is gone: it
-            for store, value in displaced:  # holds the same key, and would otherwise shadow what goes back
+        for m, displaced in displaced_collection.items():
+            for store, value in displaced:
                 store["total_ops"] = value
         _restore_modes(prev_training)  # last: it calls train(), which is the caller's code and may raise
 

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -154,14 +154,14 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=
         fn = _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 
         displaced_collection[m] = _displace_total_ops(m)
-        # matching the caller's persistence: register_buffer discards the name from _non_persistent_buffers_set
-        # when it registers a persistent one, and that set is not part of what was displaced, so a buffer the
-        # caller kept out of its state_dict would come back in it and fail a strict load.
-        m.register_buffer(
-            "total_ops",
-            torch.zeros(1, dtype=default_dtype),
-            persistent="total_ops" not in m._non_persistent_buffers_set,
-        )
+        # register_buffer discards the name from _non_persistent_buffers_set, which is not one of the stores
+        # displaced above, so a buffer the caller deliberately kept out of its state_dict would come back inside
+        # it and fail a strict load. The membership goes back by hand rather than through persistent=, which a
+        # subclass overriding register_buffer with the older two-argument signature cannot accept.
+        non_persistent = "total_ops" in m._non_persistent_buffers_set
+        m.register_buffer("total_ops", torch.zeros(1, dtype=default_dtype))
+        if non_persistent:
+            m._non_persistent_buffers_set.add("total_ops")
         handler_collection[m] = None
         if fn is not None:
             handler_collection[m] = m.register_forward_hook(fn)

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -107,18 +107,7 @@ def _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 
 
 def _displace_total_ops(m):
-    """Take whatever the caller already keeps under `total_ops` out of the counter's way, and report it back.
-
-    The name stays public because it is the documented one a custom_ops rule writes to, so a private counter would route
-    every user-written rule into an attribute nothing reads and report zero without an error. That leaves the profiler
-    occupying a name on someone else's module, which the module may already be using. nn.Module.__setattr__ refuses an
-    int for a name it finds in _buffers, which turned every rule's `m.total_ops += ...` into a TypeError; a plain
-    attribute of that name was overwritten and then removed by the teardown, leaving no trace that it had been there.
-
-    Only the two stores the profiler can vacate without changing what it measures are moved. A parameter of that name
-    feeds calculate_parameters(model.parameters()) and a child module of it feeds the traversal that sums a subtree, so
-    hiding either would answer with a smaller number instead of an error.
-    """
+    """Temporarily remove a caller-owned `total_ops` attribute or buffer."""
     displaced = [(store, store["total_ops"]) for store in (m._buffers, m.__dict__) if "total_ops" in store]
     if displaced:  # record first, remove second: nothing may run between taking the value and owning a copy
         logging.warning(f"{m!s} already has a .total_ops; it is shadowed while profiling and restored after.")
@@ -153,7 +142,8 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=
         m_type = type(m)
         fn = _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 
-        displaced_collection[m] = _displace_total_ops(m)
+        if "total_ops" in m.__dict__ or "total_ops" in m._buffers:
+            displaced_collection[m] = _displace_total_ops(m)
         # register_buffer discards the name from _non_persistent_buffers_set, which is not one of the stores
         # displaced above, so a buffer the caller deliberately kept out of its state_dict would come back inside
         # it and fail a strict load. The membership goes back by hand rather than through persistent=, which a
@@ -222,7 +212,8 @@ def profile(
         m_type = type(m)
         fn = _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 
-        displaced_collection[m] = _displace_total_ops(m)
+        if "total_ops" in m.__dict__ or "total_ops" in m._buffers:
+            displaced_collection[m] = _displace_total_ops(m)
         # a plain int attribute, not a float64 buffer: buffer reads go through nn.Module.__getattr__ and every
         # hook would allocate a tensor per call, which dominates profiling cost on module-heavy models.
         # Written straight into __dict__ (mirroring the teardown below) to skip nn.Module.__setattr__.

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -106,6 +106,27 @@ def _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
     return None
 
 
+def _displace_total_ops(m):
+    """Take whatever the caller already keeps under `total_ops` out of the counter's way, and report it back.
+
+    The name stays public because it is the documented one a custom_ops rule writes to, so a private counter would route
+    every user-written rule into an attribute nothing reads and report zero without an error. That leaves the profiler
+    occupying a name on someone else's module, which the module may already be using. nn.Module.__setattr__ refuses an
+    int for a name it finds in _buffers, which turned every rule's `m.total_ops += ...` into a TypeError; a plain
+    attribute of that name was overwritten and then removed by the teardown, leaving no trace that it had been there.
+
+    Only the two stores the profiler can vacate without changing what it measures are moved. A parameter of that name
+    feeds calculate_parameters(model.parameters()) and a child module of it feeds the traversal that sums a subtree, so
+    hiding either would answer with a smaller number instead of an error.
+    """
+    displaced = [(store, store["total_ops"]) for store in (m._buffers, m.__dict__) if "total_ops" in store]
+    if displaced:  # record first, remove second: nothing may run between taking the value and owning a copy
+        logging.warning(f"{m!s} already has a .total_ops; it is shadowed while profiling and restored after.")
+        for store, _ in displaced:
+            del store["total_ops"]
+    return displaced
+
+
 def _restore_modes(prev_training):
     """Restore each module's training mode."""
     for m, was_training in prev_training.items():
@@ -118,6 +139,7 @@ def _restore_modes(prev_training):
 def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=False):
     """Profile a model with the legacy per-leaf-module traversal, returning total operations and parameters."""
     handler_collection = {}
+    displaced_collection = {}
     types_collection = set()
     if custom_ops is None:
         custom_ops = {}
@@ -128,15 +150,18 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=
         if list(m.children()) or m in handler_collection:
             return
 
-        if hasattr(m, "total_ops"):
-            logging.warning(
-                f".total_ops is already defined in {m!s}. Be careful, it might change your code's behavior."
-            )
-
         m_type = type(m)
         fn = _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 
-        m.register_buffer("total_ops", torch.zeros(1, dtype=default_dtype))
+        displaced_collection[m] = _displace_total_ops(m)
+        # matching the caller's persistence: register_buffer discards the name from _non_persistent_buffers_set
+        # when it registers a persistent one, and that set is not part of what was displaced, so a buffer the
+        # caller kept out of its state_dict would come back in it and fail a strict load.
+        m.register_buffer(
+            "total_ops",
+            torch.zeros(1, dtype=default_dtype),
+            persistent="total_ops" not in m._non_persistent_buffers_set,
+        )
         handler_collection[m] = None
         if fn is not None:
             handler_collection[m] = m.register_forward_hook(fn)
@@ -162,6 +187,9 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=
             handler.remove()
         for m in handler_collection:
             m._buffers.pop("total_ops", None)
+        for m, displaced in displaced_collection.items():  # only once this call's own buffer is gone: it
+            for store, value in displaced:  # holds the same key, and would otherwise shadow what goes back
+                store["total_ops"] = value
         _restore_modes(prev_training)  # last: it calls train(), which is the caller's code and may raise
 
     return total_ops, total_params
@@ -178,6 +206,7 @@ def profile(
 ):
     """Profiles a PyTorch model, optionally estimating target-image MACs from smaller stride-aligned inputs."""
     handler_collection = {}
+    displaced_collection = {}
     types_collection = set()
     if custom_ops is None:
         custom_ops = {}
@@ -193,6 +222,7 @@ def profile(
         m_type = type(m)
         fn = _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 
+        displaced_collection[m] = _displace_total_ops(m)
         # a plain int attribute, not a float64 buffer: buffer reads go through nn.Module.__getattr__ and every
         # hook would allocate a tensor per call, which dominates profiling cost on module-heavy models.
         # Written straight into __dict__ (mirroring the teardown below) to skip nn.Module.__setattr__.
@@ -295,6 +325,9 @@ def profile(
             handler.remove()
         for m in handler_collection:
             m.__dict__.pop("total_ops", None)
+        for m, displaced in displaced_collection.items():  # only once this call's own counter is gone: it
+            for store, value in displaced:  # holds the same key, and would otherwise shadow what goes back
+                store["total_ops"] = value
         _restore_modes(prev_training)  # last: it calls train(), which is the caller's code and may raise
 
     if ret_layer_info:


### PR DESCRIPTION
## summary

Both entry points attach their counter under the public name `total_ops`, and neither checked whether the caller's module was already using it. Since the name is the documented one a `custom_ops` rule writes to, a model can hold it for reasons of its own.

What happened, measured on a `nn.Sequential(nn.Conv2d(3, 4, 3))` and on a bare `nn.Conv2d(3, 4, 3)`:

```
                                profile()                       profile_origin()
buffer, tensor-valued           TypeError                       counts, buffer gone on a leaf
buffer, None-valued             TypeError                       —
plain instance attribute        counts, attribute gone          counts, attribute gone
```

`nn.Module.__setattr__` looks in `_buffers` before it falls through to `object.__setattr__`, so a buffer of that name turns every rule's `m.total_ops += ...` into `TypeError: cannot assign 'int' as buffer 'total_ops'`. A plain attribute takes no such route: it was overwritten and then removed by the teardown, so the call returned an ordinary-looking number with the caller's value gone and nothing said.

`_displace_total_ops` now moves whatever the module keeps under that name out of `_buffers` and `__dict__` before the counter goes in, and each entry point puts it back in the `finally` it already had, after its own counter is removed — the other order leaves the counter shadowing what was restored. All twelve combinations of the three cases above, each entry point, container and leaf, now report the same counts as the same model without the collision, with the caller's value intact and its persistence flag unchanged.

A parameter or a child module of that name is left where it is. Both are inside what the profile measures — a parameter is summed by `calculate_parameters(model.parameters())`, a child module is walked by the traversal that totals a subtree — so vacating either would answer with a smaller number rather than an error. Those cases are unchanged by this: `profile()` raises as it did, and `profile_origin` returns what it did, which for a container is a correct count, since it installs nothing on a module that has children.

`profile_origin` installs its counter through `register_buffer`, which discards the name from `_non_persistent_buffers_set` when it registers a persistent buffer. That set is not one of the stores being displaced, so it now passes the caller's own persistence through: a buffer deliberately kept out of `state_dict()` comes back out of it, rather than turning into a key that fails a strict load.

`profile_origin` warned when the name was taken; `profile` did not. The warning moves to the shared helper, so both emit it, and says what now happens: the caller's value is shadowed for the duration of the call and restored afterwards. It is still worth saying, because a module whose `forward` reads `self.total_ops` sees the counter while profiling.

## verification

- 15 torchvision models, both entry points over every registry family, `stride=`, `ret_layer_info`, `custom_ops`, an activation shared between two parents, and an LSTM: 49 measured figures, byte-identical before and after.
- `get_flops` from `ultralytics` on `yolo11n` and `yolov8s`: unchanged, 6.6118784 and 28.811929600000003 on both.
- A module with no collision gains no attribute and loses none; an exception during the forward still restores the caller's value through the `finally`.

### Measured impact

Twelve cases: three ways a caller can hold the name — a tensor buffer, a `None` buffer, a plain attribute — across both entry points, on a leaf and on a container, each checked against the same model profiled without the collision.

Before, 3 of 12 returned the right count with the caller's value intact. Five raised, four of them `TypeError` and one `KeyError`. The remaining four returned an ordinary-looking 3,888.0 with the caller's value gone and nothing said, which is the case a caller cannot notice.

After, 12 of 12: the same 3,888.0 every time, and every stored value back as it was.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛡️ THOP now safely preserves and restores existing `total_ops` attributes or buffers during model profiling.

### 📊 Key Changes

- Added logic to temporarily remove any caller-defined `total_ops` attributes or buffers before profiling.
- Restores the original `total_ops` values after profiling completes.
- Preserves non-persistent buffer behavior when profiling with the legacy `profile_origin` flow.
- Added warnings when an existing `total_ops` value is temporarily shadowed.
- Applied the protection to both `profile_origin()` and `profile()`.

### 🎯 Purpose & Impact

- ✅ Prevents profiling from overwriting model-owned `total_ops` data.
- 🔄 Reduces unintended changes to user models and improves profiling safety.
- 📈 Maintains compatibility with modules that already use `total_ops` internally.
- 🧹 Ensures temporary profiling state is cleaned up even after hooks are removed, preserving expected model behavior.