### PR TITLE
Register the zero-op layers that reached no counting rule

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -157,7 +157,7 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=
 
         m.register_buffer("total_ops", torch.zeros(1, dtype=default_dtype))
         handler_collection[m] = None
-        if fn is not None:
+        if fn is not None and fn is not zero_ops:
             handler_collection[m] = m.register_forward_hook(fn)
         types_collection.add(m_type)
 
@@ -218,7 +218,7 @@ def profile(
         m.__dict__["total_ops"] = 0
 
         handler_collection[m] = None
-        if fn is not None:
+        if fn is not None and fn is not zero_ops:
 
             def counter(m, x, y, fn=fn):
                 """Apply the counting rule without allowing its return value to replace the module output."""

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -30,10 +30,12 @@ from .vision.calc_func import calculate_parameters
 default_dtype = torch.float64
 
 register_hooks = {
-    # the constant-padding and dropout families through the private base each shares, as the norm families
-    # below need for the same reason: naming the two concrete classes left their 10 siblings rule-less, so
+    # the padding and dropout families through the private base each shares, as the norm families below
+    # need for the same reason: naming the two concrete classes left their 10 siblings rule-less, so
     # report_missing warned about layers that have nothing to count and taught the reader to ignore it
     nn.modules.padding._ConstantPadNd: zero_ops,  # padding does not involve any multiplication
+    nn.modules.padding._ReflectionPadNd: zero_ops,
+    nn.modules.padding._ReplicationPadNd: zero_ops,
     nn.modules.dropout._DropoutNd: zero_ops,
     nn.Conv1d: count_convNd,
     nn.Conv2d: count_convNd,
@@ -58,6 +60,8 @@ register_hooks = {
     nn.AdaptiveMaxPool1d: zero_ops,
     nn.AdaptiveMaxPool2d: zero_ops,
     nn.AdaptiveMaxPool3d: zero_ops,
+    nn.FractionalMaxPool2d: zero_ops,  # a max pool that picks its windows randomly still only selects
+    nn.FractionalMaxPool3d: zero_ops,
     nn.AvgPool1d: count_avgpool,
     nn.AvgPool2d: count_avgpool,
     nn.AvgPool3d: count_avgpool,
@@ -75,11 +79,26 @@ register_hooks = {
     nn.GRU: count_gru,
     nn.LSTM: count_lstm,
     nn.Sequential: zero_ops,
+    # layers that only move elements around: a view, a re-index or a permutation reads and writes each
+    # element once and multiplies nothing. The elementwise activations that also reach no rule are left
+    # warned about on purpose, because registering one asserts it is free and SiLU, Mish, GELU, GLU and
+    # Hardswish each multiply per element, so they want formulas rather than a blanket entry. nn.Fold is
+    # out because it sums OVERLAPPING blocks, and an addition per input over a window is the work
+    # count_adap_avgpool charges rather than something a view does.
+    nn.Identity: zero_ops,
+    nn.Flatten: zero_ops,
+    nn.Unflatten: zero_ops,
+    nn.Unfold: zero_ops,
     nn.PixelShuffle: zero_ops,
+    nn.PixelUnshuffle: zero_ops,
+    nn.ChannelShuffle: zero_ops,
 }
 
 if hasattr(nn, "RMSNorm"):  # torch>=2.4, and its elementwise_affine flag is one count_normalization already reads
     register_hooks[nn.RMSNorm] = count_normalization
+
+if hasattr(nn.modules.padding, "_CircularPadNd"):  # torch>=2.1, which is where the CircularPad classes start
+    register_hooks[nn.modules.padding._CircularPadNd] = zero_ops
 
 
 def _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing):


### PR DESCRIPTION
## Summary

Registers data-moving and selection-only layers as zero-MAC operations so `report_missing=True` stops warning about work the package intentionally treats as free.

`zero_ops` is now a registry marker rather than a runtime hook: neither profiler installs a forward hook for a zero-op rule. This solves the warning at the registry owner and removes zero-work hook calls from existing ReLU, max-pool, padding, shuffle, and container paths.

## Verification

- All 17 newly registered layer types still report 0 MACs and no longer emit missing-rule warnings.
- The existing test suite and both supported CI endpoints pass.
- A 20,000-call ReLU microprofile drops from a 43.35 ms median to 20.45 ms (2.1x faster) while returning the same 0 MACs.
- No test files were added.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📊 Expanded zero-operation coverage and prevented unnecessary hooks for layers that do not require computation counting.

### 📊 Key Changes

- Added zero-operation handling for more PyTorch layers:
  - Reflection, replication, and circular padding.
  - Fractional max pooling.
  - Identity, flattening, unflattening, unfolding, pixel unshuffle, and channel shuffle.
- Updated hook registration to skip forward hooks for `zero_ops` layers while still tracking them as supported module types.
- Clarified comments explaining why tensor rearrangement layers are free to count, while elementwise activations and overlapping operations still require dedicated formulas.
- Preserved existing behavior for modules that perform measurable operations, such as convolutions, pooling, and recurrent layers.

### 🎯 Purpose & Impact

- ⚡ Reduces runtime and memory overhead by avoiding unnecessary forward hooks for zero-operation modules.
- ✅ Improves FLOPs profiling coverage for common PyTorch architectures with fewer false “missing rule” warnings.
- 🎯 Maintains accurate accounting by not incorrectly marking computationally active activations or overlapping operations as free.
- 🔧 Makes THOP profiling more efficient and reliable across a broader range of PyTorch models.