### PR TITLE
Count the whole softmax family and stop dividing by an empty axis

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -48,10 +48,9 @@ register_hooks = {
     nn.LayerNorm: count_normalization,
     nn.GroupNorm: count_normalization,
     nn.PReLU: count_prelu,
-    # the whole softmax family, which shares no base. Softmax2d is a softmax over the channel axis and Softmin
-    # is a softmax of the negated input, both of which count_softmax reads off the module. LogSoftmax is the
-    # one that is charged as a plain softmax: its extra logarithm is one operation per normalized vector, an
-    # order below the exponential, addition and division this already charges for every element of that vector
+    # the whole softmax family, which shares no base, so each member is named. They differ from a plain softmax
+    # by the channel axis Softmax2d normalizes, the negation Softmin applies and the logarithm LogSoftmax takes,
+    # and count_softmax reads all three off the module rather than needing a rule apiece
     nn.Softmax: count_softmax,
     nn.LogSoftmax: count_softmax,
     nn.Softmin: count_softmax,

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -48,9 +48,7 @@ register_hooks = {
     nn.LayerNorm: count_normalization,
     nn.GroupNorm: count_normalization,
     nn.PReLU: count_prelu,
-    # the whole softmax family, which shares no base, so each member is named. They differ from a plain softmax
-    # by the channel axis Softmax2d normalizes, the negation Softmin applies and the logarithm LogSoftmax takes,
-    # and count_softmax reads all three off the module rather than needing a rule apiece
+    # The softmax family shares no base, so each member is registered explicitly.
     nn.Softmax: count_softmax,
     nn.LogSoftmax: count_softmax,
     nn.Softmin: count_softmax,

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -48,9 +48,10 @@ register_hooks = {
     nn.LayerNorm: count_normalization,
     nn.GroupNorm: count_normalization,
     nn.PReLU: count_prelu,
-    # the whole softmax family, which shares no base: Softmin is a softmax of the negated input and LogSoftmax
-    # adds one logarithm per normalized vector, both below the granularity a rule that prices an exponential at
-    # one operation can express, and Softmax2d is a softmax over the channel axis that count_softmax resolves
+    # the whole softmax family, which shares no base. Softmax2d is a softmax over the channel axis and Softmin
+    # is a softmax of the negated input, both of which count_softmax reads off the module. LogSoftmax is the
+    # one that is charged as a plain softmax: its extra logarithm is one operation per normalized vector, an
+    # order below the exponential, addition and division this already charges for every element of that vector
     nn.Softmax: count_softmax,
     nn.LogSoftmax: count_softmax,
     nn.Softmin: count_softmax,

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -48,7 +48,13 @@ register_hooks = {
     nn.LayerNorm: count_normalization,
     nn.GroupNorm: count_normalization,
     nn.PReLU: count_prelu,
+    # the whole softmax family, which shares no base: Softmin is a softmax of the negated input and LogSoftmax
+    # adds one logarithm per normalized vector, both below the granularity a rule that prices an exponential at
+    # one operation can express, and Softmax2d is a softmax over the channel axis that count_softmax resolves
     nn.Softmax: count_softmax,
+    nn.LogSoftmax: count_softmax,
+    nn.Softmin: count_softmax,
+    nn.Softmax2d: count_softmax,
     nn.ReLU: zero_ops,
     nn.ReLU6: zero_ops,
     nn.LeakyReLU: zero_ops,

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -108,6 +108,8 @@ def count_softmax(m, x, y):
     batch_size = x.numel() // nfeatures if nfeatures else 0
 
     m.total_ops += calculate_softmax(batch_size, nfeatures)
+    if isinstance(m, nn.Softmin):  # torch runs it as (-x).softmax(dim), and that negation is one op per element
+        m.total_ops += x.numel()
 
 
 def count_avgpool(m, x, y):

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -93,26 +93,20 @@ def count_prelu(m, x, y):
 def count_softmax(m, x, y):
     """Calculate and update the total operation counts for a Softmax layer in a PyTorch model."""
     x = x[0]
-    # nn.Softmax2d owns no dim at all: it always normalizes the channel axis, which is the third from the end
-    # for both the batched and the unbatched input it accepts. Naming the one class it holds for keeps every
-    # other dim-less module raising as it did, rather than being handed a channel axis it never asked for
+    # Softmax2d always normalizes channels, with or without a batch dimension.
     dim = -3 if isinstance(m, nn.Softmax2d) else m.dim
     if dim is None:
-        # nn.Softmax(dim=None) is deprecated but still legal and still runs, resolving the dimension itself, so
-        # the count follows that rule rather than raising: dimension 0 for 0-, 1- and 3-dimensional input, 1 otherwise
+        # Match torch's deprecated implicit dimension.
         dim = 0 if x.dim() in {0, 1, 3} else 1
     # a scalar normalizes over itself, which no shape entry can say: torch returns 1.0 for it, so the cost is
     # the one exponential and the one division that produce that, and indexing the empty shape only raises
     nfeatures = x.size()[dim] if x.dim() else 1
-    # an empty normalized axis is no work at all, and it leaves no vector count to divide out of the element count
     batch_size = x.numel() // nfeatures if nfeatures else 0
 
     m.total_ops += calculate_softmax(batch_size, nfeatures)
-    # what each variant costs on top of the plain softmax. Both terms are worth writing because calculate_softmax
-    # charges nfeatures - 1 additions rather than nfeatures, so it is already exact to within one op per vector
-    if isinstance(m, nn.Softmin):  # torch runs it as (-x).softmax(dim), one negation per element
+    if isinstance(m, nn.Softmin):
         m.total_ops += x.numel()
-    elif isinstance(m, nn.LogSoftmax):  # torch runs it as x - logsumexp(x), one logarithm per normalized vector
+    elif isinstance(m, nn.LogSoftmax):
         m.total_ops += batch_size
 
 

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -93,13 +93,19 @@ def count_prelu(m, x, y):
 def count_softmax(m, x, y):
     """Calculate and update the total operation counts for a Softmax layer in a PyTorch model."""
     x = x[0]
-    # nn.Softmax(dim=None) is deprecated but still legal and still runs, resolving the dimension itself, so the
-    # count follows the same rule rather than raising: dimension 0 for 0-, 1- and 3-dimensional input, 1 otherwise
-    dim = m.dim if m.dim is not None else 0 if x.dim() in {0, 1, 3} else 1
+    # nn.Softmax2d owns no dim at all: it always normalizes the channel axis, which is the third from the end
+    # for both the batched and the unbatched input it accepts. Naming the one class it holds for keeps every
+    # other dim-less module raising as it did, rather than being handed a channel axis it never asked for
+    dim = -3 if isinstance(m, nn.Softmax2d) else m.dim
+    if dim is None:
+        # nn.Softmax(dim=None) is deprecated but still legal and still runs, resolving the dimension itself, so
+        # the count follows that rule rather than raising: dimension 0 for 0-, 1- and 3-dimensional input, 1 otherwise
+        dim = 0 if x.dim() in {0, 1, 3} else 1
     # a scalar normalizes over itself, which no shape entry can say: torch returns 1.0 for it, so the cost is
     # the one exponential and the one division that produce that, and indexing the empty shape only raises
     nfeatures = x.size()[dim] if x.dim() else 1
-    batch_size = x.numel() // nfeatures
+    # an empty normalized axis is no work at all, and it leaves no vector count to divide out of the element count
+    batch_size = x.numel() // nfeatures if nfeatures else 0
 
     m.total_ops += calculate_softmax(batch_size, nfeatures)
 

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -108,8 +108,12 @@ def count_softmax(m, x, y):
     batch_size = x.numel() // nfeatures if nfeatures else 0
 
     m.total_ops += calculate_softmax(batch_size, nfeatures)
-    if isinstance(m, nn.Softmin):  # torch runs it as (-x).softmax(dim), and that negation is one op per element
+    # what each variant costs on top of the plain softmax. Both terms are worth writing because calculate_softmax
+    # charges nfeatures - 1 additions rather than nfeatures, so it is already exact to within one op per vector
+    if isinstance(m, nn.Softmin):  # torch runs it as (-x).softmax(dim), one negation per element
         m.total_ops += x.numel()
+    elif isinstance(m, nn.LogSoftmax):  # torch runs it as x - logsumexp(x), one logarithm per normalized vector
+        m.total_ops += batch_size
 
 
 def count_avgpool(m, x, y):


### PR DESCRIPTION
## summary

`nn.LogSoftmax`, `nn.Softmin` and `nn.Softmax2d` reached no counting rule, so each was charged zero MACs while doing the same exponentiate, sum and divide over the same tensor that `nn.Softmax` is counted for. They share no private base, so each member is named.

All three then differ from a plain softmax by one term, and `count_softmax` reads each off the module rather than needing a rule apiece:

- `nn.Softmax2d` carries no `dim` attribute at all. It always normalizes the channel axis, which is the third from the end for both the batched and the unbatched input it accepts.
- `nn.Softmin` runs as `(-x).softmax(dim)`, so it negates every element first — one operation per element.
- `nn.LogSoftmax` runs as `x - logsumexp(x)`, so it takes one logarithm per normalized vector.

Both extra terms are worth writing because `calculate_softmax` charges `nfeatures - 1` additions rather than `nfeatures`: the formula is already exact to within one operation per vector, which is the size of the smaller of the two.

The resolution for a `dim=None` softmax is unchanged and still runs for the three classes that do have the attribute.

Separately, `count_softmax` derived the number of normalized vectors by dividing the element count by the axis length, which raised `ZeroDivisionError` when that axis was empty. torch runs the layer, so a model that works could not be profiled:

```python
nn.Softmax(dim=1)(torch.zeros(2, 0))  # torch.Size([2, 0])
profile(nn.Sequential(nn.Softmax(dim=1)), inputs=(torch.zeros(2, 0),), verbose=False)
```

An empty axis is no work at all and leaves no vector count to divide out, so it now reports 0.

No published figure moves. Neither the README benchmark table nor any torchvision model instantiates one of these four as a module, a fifteen-model torchvision differential is byte-identical, and both README worked examples still produce the values they print.

### Measured impact

Over an `8x1000` input, with `nn.Softmax` alongside as the member that was already counted:

| layer                            | before | after   |
| -------------------------------- | ------ | ------- |
| `nn.Softmax(dim=1)`              | 23,992 | 23,992  |
| `nn.LogSoftmax(dim=1)`           | 0      | 24,000  |
| `nn.Softmin(dim=1)`              | 0      | 31,992  |
| `nn.Softmax2d` over `1x64x32x32` | 0      | 195,584 |

Each of the three lands where its one extra term puts it: `nn.LogSoftmax` 8 above the plain softmax, one logarithm per normalized vector, and `nn.Softmin` 8,000 above it, one negation per element, +33%.

`nn.Softmax(dim=1)` over a `(2, 0)` input raised `ZeroDivisionError` and now reports 0.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧮 Adds operation-counting support for PyTorch `LogSoftmax`, `Softmin`, and `Softmax2d` layers with improved edge-case handling.

### 📊 Key Changes

- Registers `nn.LogSoftmax`, `nn.Softmin`, and `nn.Softmax2d` with the existing softmax counting hook.
- Updates `count_softmax` to:
  - Handle `Softmax2d` normalization across channels, including inputs with or without a batch dimension.
  - Preserve PyTorch’s behavior for deprecated implicit dimension selection.
  - Safely process scalar and zero-feature inputs.
  - Add operation costs specific to `Softmin` and `LogSoftmax`.

### 🎯 Purpose & Impact

- ✅ Produces more accurate FLOP and operation estimates for models using the full PyTorch softmax family.
- 🛡️ Improves robustness for scalar, empty, and unusual input shapes.
- 📈 Helps profiling tools better reflect the computational cost of classification and normalization layers without affecting existing supported layers.