### PR TITLE
Answer for the tree the forward pass ran, not the one it left behind

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -107,12 +107,7 @@ def _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 
 
 def _parents_first(roots):
-    """List every module reachable from roots, each after every module whose train() recurses into it.
-
-    Every recorded module is a root of the walk, not just the model: one the forward pass detached is unreachable from
-    the model and is still a module train() gets called on. Reverse postorder rather than a plain descent, because a
-    module held by two parents has to follow both of them however they were reached.
-    """
+    """List reachable modules with every parent before its children."""
     order, seen = [], set()
 
     def visit(m):
@@ -130,13 +125,7 @@ def _parents_first(roots):
 
 
 def _restore_modes(prev_training):
-    """Restore the training mode of every module this call recorded, and of no other.
-
-    The walk is over the tree as it stands after the forward pass, since that is the one train() recurses over. A module
-    the forward pass attached was never recorded and its mode is its creator's to choose, so its own mode stands in for
-    the snapshot it has none of; a parent going back first means every such module is written once, by itself, after
-    everything that could reach it.
-    """
+    """Restore recorded modes without changing modules attached during forward."""
     order = _parents_first(prev_training)
     modes = {m: prev_training.get(m, m.training) for m in order}  # read before the first train() call moves any
     for m, was_training in modes.items():
@@ -242,14 +231,7 @@ def profile(
     counted = set()
 
     def dfs_count(module: nn.Module, prefix="\t") -> (float, dict):
-        """Recursively count the operations of a module and its submodules, for the per-layer report.
-
-        This walks the tree the forward pass left behind, so a module it replaced or detached is missing from it. The
-        total the call returns is read off the hook record instead and can therefore exceed this sum; the parameter
-        counts beside it come from the same surviving tree, as the ones the call returns do.
-        """
-        # only a counter this call installed is read, so a module the forward pass attached carrying an attribute of
-        # that name contributes its own bookkeeping to nothing. A custom rule may accumulate a tensor, hence float().
+        """Build layer details from the module tree left after forward."""
         total_ops = float(module.__dict__.get("total_ops", 0)) if module in handler_collection else 0.0
         ret_dict = {}
         for n, m in module.named_children():
@@ -279,9 +261,7 @@ def profile(
                 m.__dict__["total_ops"] = 0
             with torch.no_grad():
                 model(*input_values)
-            # the record rather than the tree: a module the forward pass replaced or detached still did the work its
-            # hook counted, and profile_origin has always reported it. dfs_count answers for the tree the caller is
-            # left with, which is what the per-layer report describes, so it runs only when that report is asked for
+            # Count the executed hook record; build the surviving tree only when requested.
             total = sum(float(m.__dict__.get("total_ops", 0)) for m in handler_collection)
             return total, dfs_count(model)[1] if ret_layer_info else {}
 

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -106,12 +106,43 @@ def _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
     return None
 
 
+def _parents_first(roots):
+    """List every module reachable from roots, each after every module whose train() recurses into it.
+
+    Every recorded module is a root of the walk, not just the model: one the forward pass detached is unreachable from
+    the model and is still a module train() gets called on. Reverse postorder rather than a plain descent, because a
+    module held by two parents has to follow both of them however they were reached.
+    """
+    order, seen = [], set()
+
+    def visit(m):
+        seen.add(m)
+        for c in m.children():
+            if c not in seen:
+                visit(c)
+        order.append(m)
+
+    for root in roots:
+        if root not in seen:
+            visit(root)
+    order.reverse()
+    return order
+
+
 def _restore_modes(prev_training):
-    """Restore each module's training mode."""
-    for m, was_training in prev_training.items():
+    """Restore the training mode of every module this call recorded, and of no other.
+
+    The walk is over the tree as it stands after the forward pass, since that is the one train() recurses over. A module
+    the forward pass attached was never recorded and its mode is its creator's to choose, so its own mode stands in for
+    the snapshot it has none of; a parent going back first means every such module is written once, by itself, after
+    everything that could reach it.
+    """
+    order = _parents_first(prev_training)
+    modes = {m: prev_training.get(m, m.training) for m in order}  # read before the first train() call moves any
+    for m, was_training in modes.items():
         if m.training != was_training:
             m.train(was_training)
-    for m, was_training in prev_training.items():
+    for m, was_training in modes.items():
         m.training = was_training
 
 
@@ -211,9 +242,15 @@ def profile(
     counted = set()
 
     def dfs_count(module: nn.Module, prefix="\t") -> (float, dict):
-        """Recursively counts the total operations of the given PyTorch module and its submodules."""
-        # A custom rule may accumulate a tensor, and a module added during the forward has no temporary attribute.
-        total_ops = float(module.__dict__.get("total_ops", 0))
+        """Recursively count the operations of a module and its submodules, for the per-layer report.
+
+        This walks the tree the forward pass left behind, so a module it replaced or detached is missing from it. The
+        total the call returns is read off the hook record instead and can therefore exceed this sum; the parameter
+        counts beside it come from the same surviving tree, as the ones the call returns do.
+        """
+        # only a counter this call installed is read, so a module the forward pass attached carrying an attribute of
+        # that name contributes its own bookkeeping to nothing. A custom rule may accumulate a tensor, hence float().
+        total_ops = float(module.__dict__.get("total_ops", 0)) if module in handler_collection else 0.0
         ret_dict = {}
         for n, m in module.named_children():
             # every child is walked, whether or not it carries a rule of its own: a rule accounts for its
@@ -242,7 +279,11 @@ def profile(
                 m.__dict__["total_ops"] = 0
             with torch.no_grad():
                 model(*input_values)
-            return dfs_count(model)
+            # the record rather than the tree: a module the forward pass replaced or detached still did the work its
+            # hook counted, and profile_origin has always reported it. dfs_count answers for the tree the caller is
+            # left with, which is what the per-layer report describes, so it runs only when that report is asked for
+            total = sum(float(m.__dict__.get("total_ops", 0)) for m in handler_collection)
+            return total, dfs_count(model)[1] if ret_layer_info else {}
 
         if stride is None or ret_layer_info:
             total_ops, ret_dict = run(inputs)


### PR DESCRIPTION
## summary

`profile` summed the module tree as it stands after the forward pass and `profile_origin` summed the record of what it hooked. A forward pass that replaces or detaches one of its own submodules makes those two trees differ, so one model reported 16.0 MACs through one entry point and 0.0 through the other. The total now comes from the record in both: it is the count of the call that actually ran. `dfs_count` still builds the `ret_layer_info` tree, which describes the tree the caller is left with, and its docstring now says which of the two each returned value answers for.

The mode restore had the mirror problem. Its first pass is `train()`, which recurses over the tree as it stands now, so it reached a submodule the forward pass had just created — one the snapshot knew nothing about, in the mode its creator chose for it. Those modules are read before the recursion can reach them and put back afterwards through their own `train()`, which is what an override keeping state beside the flag needs. Every recorded module is walked rather than only the root, because a module the forward pass detached is still one `train()` is called on and that call still recurses into whatever now hangs off it.

Reading the per-layer numbers off the record as well means a module the profiler never hooked no longer contributes an attribute of that name to the report it was never asked to count.

Measured byte-identical against `main`: 15 torchvision models through `profile`, five of them through `profile_origin`, 1347 nested `ret_layer_info` entries across six models, both README examples, the stride estimate against the plain call, and `get_flops` on yolo11n, yolov8s and yolo26n. The ordering walk visits each module once and costs 0.158 ms on a 319-module model; three interleaved timing rounds put the whole call at 52.6/51.8/51.1 ms against 54.2/53.2/53.2 ms before, since the per-layer tree is no longer built when it is discarded.

### Measured impact

A model whose forward pass replaces the submodule it just ran reported 0.0 MACs through `profile` and 16.0 through `profile_origin` — the two entry points disagreeing about the whole model, one of them by 100% of it. Both now report 16.0.

A submodule the forward pass attaches mid-pass in eval mode came back in training mode; it now comes back in the mode its creator chose.

Cost does not regress. On densenet121, 433 modules, medians of medians over three interleaved rounds: 22.03 / 22.66 / 24.76 ms before against 21.98 / 22.36 / 22.73 ms after.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ Improves THOP profiling for models that dynamically add modules or change training modes during forward execution.

### 📊 Key Changes
- Added parent-first module traversal to safely restore training modes after profiling.
- Prevents restoration logic from unintentionally modifying modules created or attached during the forward pass.
- Updated operation counting to include only modules with registered profiling handlers.
- Separates total operation counting from optional layer-detail generation for more reliable results.
- Preserves profiling information for dynamically created modules without requiring temporary attributes.

### 🎯 Purpose & Impact
- ✅ Makes profiling more robust for dynamic PyTorch model architectures.
- ✅ Avoids incorrect operation totals caused by modules added during execution.
- ✅ Maintains model training and evaluation states more accurately after profiling.
- ⚡ May improve efficiency when only total operations are requested, since detailed layer information is skipped unless enabled.