### PR TITLE
Accept any callable as a custom_ops counting rule

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -88,10 +88,6 @@ def _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
     The whole MRO is walked, most derived first, so a subclass of a supported type is counted by that type's rule
     instead of being skipped, and a lazy module resolves through the class it derives from. custom_ops is consulted
     ahead of the built-ins at every level, so a caller's own rule still wins.
-
-    A rule is named for the message alone, and only what the object says about itself: a functools.partial and an
-    instance of a callable class are ordinary ways to supply a parameterized rule and neither carries __qualname__, so
-    reading it decided which callables were allowed at all.
     """
     first_seen = m_type not in types_collection
     for t in m_type.__mro__:

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -88,18 +88,22 @@ def _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
     The whole MRO is walked, most derived first, so a subclass of a supported type is counted by that type's rule
     instead of being skipped, and a lazy module resolves through the class it derives from. custom_ops is consulted
     ahead of the built-ins at every level, so a caller's own rule still wins.
+
+    A rule is named for the message alone, and only what the object says about itself: a functools.partial and an
+    instance of a callable class are ordinary ways to supply a parameterized rule and neither carries __qualname__, so
+    reading it decided which callables were allowed at all.
     """
     first_seen = m_type not in types_collection
     for t in m_type.__mro__:
         if t in custom_ops:  # if defined in both op maps, custom_ops overwrites
             fn = custom_ops[t]
             if first_seen and verbose:
-                print(f"[INFO] Customize rule {fn.__qualname__}() {m_type}.")
+                print(f"[INFO] Customize rule {getattr(fn, '__qualname__', fn)}() {m_type}.")
             return fn
         if t in register_hooks:
             fn = register_hooks[t]
             if first_seen and verbose:
-                print(f"[INFO] Register {fn.__qualname__}() for {m_type}.")
+                print(f"[INFO] Register {getattr(fn, '__qualname__', fn)}() for {m_type}.")
             return fn
     if first_seen and report_missing:
         prRed(f"[WARN] Cannot find rule for {m_type}. Treat it as zero Macs.")


### PR DESCRIPTION
`_resolve_rule` printed `fn.__qualname__` when announcing which rule it picked for a module type. A plain function carries that attribute; a `functools.partial` and an instance of a callable class do not, and both are ordinary ways to supply a parameterized `custom_ops` rule. `verbose=True` is the default, so the announcement is on by default and the call raised `AttributeError` before the forward pass:

```python
import functools
import torch
from torch import nn
from thop import profile

def scaled(m, x, y, scale=1):
    m.total_ops += 0

profile(
    nn.Sequential(nn.Conv2d(3, 4, 3)),
    inputs=(torch.randn(1, 3, 8, 8),),
    custom_ops={nn.Conv2d: functools.partial(scaled, scale=2)},
)
# AttributeError: 'functools.partial' object has no attribute '__qualname__'
```

The message now names a rule by what the object says about itself, so which callables may be a rule is no longer decided by an informational line. A `functools.partial` renders as `functools.partial(<function scaled at 0x...>, scale=2)`; for a plain function the message is byte-identical to before.

Verified on both entry points, with a `functools.partial` and with an instance of a callable class. The existing suite passes unchanged.

### Measured impact

Four kinds of callable supplied as a `custom_ops` rule, across both entry points: 4 of 8 ran before, 8 of 8 now.

A plain function and a lambda carry `__qualname__` and were unaffected. A `functools.partial` and an instance of a callable class do not, and each raised `AttributeError` on both entry points before the forward pass — the two shapes a parameterized rule ordinarily takes. Both now report the 14.0 their `scale=2` asks for, against a plain rule's 7.0.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves THOP’s verbose logging to safely display operation rules that are callable objects, not just functions.

### 📊 Key Changes
- Updated rule-name logging in `thop/profile.py` to use a safe fallback:
  - Displays `__qualname__` when available.
  - Otherwise displays the callable object itself.
- Applied the fix to both custom operation rules and registered hooks.
- Preserved existing profiling behavior and warning messages.

### 🎯 Purpose & Impact
- Prevents errors when verbose profiling encounters callable instances without a `__qualname__` attribute. 🛠️
- Makes custom operation handlers and hooks easier to debug and inspect. 🔍
- Improves compatibility without changing MACs calculation results or existing APIs. ✅