### PR TITLE
Keep attention profiling compatible with torch 1.x

### DIFF
--- a/thop/__init__.py
+++ b/thop/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 
 import torch
 

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -81,7 +81,6 @@ register_hooks = {
     nn.AdaptiveAvgPool3d: count_adap_avgpool,
     nn.Linear: count_linear,
     nn.Bilinear: count_bilinear,
-    nn.MultiheadAttention: count_multihead_attention,
     nn.Upsample: count_upsample,
     nn.UpsamplingBilinear2d: count_upsample,
     nn.UpsamplingNearest2d: count_upsample,
@@ -106,6 +105,9 @@ register_hooks = {
     nn.PixelUnshuffle: zero_ops,
     nn.ChannelShuffle: zero_ops,
 }
+
+if _HOOK_TAKES_KWARGS:
+    register_hooks[nn.MultiheadAttention] = count_multihead_attention
 
 if hasattr(nn, "RMSNorm"):  # torch>=2.4, and its elementwise_affine flag is one count_normalization already reads
     register_hooks[nn.RMSNorm] = count_normalization


### PR DESCRIPTION
## Summary

Register the built-in `nn.MultiheadAttention` rule only when PyTorch forward hooks expose keyword arguments.

Torch 1.x cannot show hook observers keyword-only key/value inputs, so attempting to reconstruct those calls can crash. It now retains the pre-2.1.3 behavior—zero attention MACs without changing model execution—while torch 2.x keeps accurate attention counting.

Bumps the corrective release to 2.1.5.

Deleted: unconditional attention-rule registration on hook APIs that cannot supply its inputs.

## Validation

- Torch 2.x mixed cross-attention with `need_weights=False`: 920 MACs through both profiler APIs.
- Torch 1.x hook-boundary emulation: 0 MACs without an exception through both APIs.
- Existing suite: 20 passed.
- Ruff check/format and `git diff --check` pass.
- No test code added.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated THOP to version 2.1.5 with improved compatibility for profiling PyTorch multi-head attention layers. 🚀

### 📊 Key Changes
- Bumped the package version from `2.1.4` to `2.1.5`.
- Registered `nn.MultiheadAttention` profiling hooks only when `_HOOK_TAKES_KWARGS` is supported.
- Prevented multi-head attention hooks from being registered in incompatible PyTorch environments.

### 🎯 Purpose & Impact
- ✅ Improves compatibility across different PyTorch versions and hook APIs.
- 🛠️ Avoids potential profiling errors involving `nn.MultiheadAttention`.
- 📈 Preserves FLOPs and parameter profiling support where the required hook functionality is available.