### PR TITLE
Count a packed sequence by its real steps and read the LSTM projection

### DIFF
--- a/thop/rnn_hooks.py
+++ b/thop/rnn_hooks.py
@@ -5,17 +5,11 @@ from torch import nn
 from torch.nn.utils.rnn import PackedSequence
 
 
-def _batch_and_steps(m, x):
-    """Return the batch size and the number of time steps a recurrent layer's input carries.
-
-    torch has accepted unbatched input since 1.9, as a (L, H_in) sequence with no batch axis at all, and it ignores
-    batch_first for it. Reading an axis by position would take the sequence length for a batch there.
-    """
+def _cell_evaluations(x):
+    """Return how many cell evaluations a recurrent layer's input asks for."""
     if isinstance(x, PackedSequence):
-        return torch.max(x.batch_sizes), x.batch_sizes.size(0)
-    if x.dim() == 2:
-        return 1, x.size(0)
-    return (x.size(0), x.size(1)) if m.batch_first else (x.size(1), x.size(0))
+        return int(x.batch_sizes.sum())  # the padded rectangle is the work packing exists to avoid
+    return x.size(0) if x.dim() == 2 else x.size(0) * x.size(1)  # unbatched (L, H_in) carries no batch axis
 
 
 def _count_rnn_cell(input_size, hidden_size, bias=True):
@@ -71,15 +65,16 @@ def count_gru_cell(m: nn.GRUCell, x: torch.Tensor, y: torch.Tensor):
     m.total_ops += int(total_ops)
 
 
-def _count_lstm_cell(input_size, hidden_size, bias=True):
+def _count_lstm_cell(input_size, hidden_size, bias=True, proj_size=0):
     """Counts LSTM cell operations during inference based on input size, hidden size, and bias configuration."""
     total_ops = 0
+    real_hidden_size = proj_size or hidden_size  # what the recurrent matmuls read, torch's own name for it
 
     # i = \sigma(W_{ii} x + b_{ii} + W_{hi} h + b_{hi}) \\
     # f = \sigma(W_{if} x + b_{if} + W_{hf} h + b_{hf}) \\
     # o = \sigma(W_{io} x + b_{io} + W_{ho} h + b_{ho}) \\
     # g = \tanh(W_{ig} x + b_{ig} + W_{hg} h + b_{hg}) \\
-    state_ops = (input_size + hidden_size) * hidden_size + hidden_size
+    state_ops = (input_size + real_hidden_size) * hidden_size + hidden_size
     if bias:
         state_ops += hidden_size * 2
     total_ops += state_ops * 4
@@ -88,8 +83,8 @@ def _count_lstm_cell(input_size, hidden_size, bias=True):
     # hadamard hadamard add
     total_ops += hidden_size * 3
 
-    # h' = o * \tanh(c') \\
-    total_ops += hidden_size
+    # h' = W_{hr} (o * \tanh(c')) \\
+    total_ops += hidden_size + hidden_size * proj_size
 
     return total_ops
 
@@ -111,7 +106,7 @@ def count_rnn(m: nn.RNN, x, y):
     hidden_size = m.hidden_size
     num_layers = m.num_layers
 
-    batch_size, num_steps = _batch_and_steps(m, x[0])
+    evaluations = _cell_evaluations(x[0])
 
     total_ops = 0
     if m.bidirectional:
@@ -125,10 +120,7 @@ def count_rnn(m: nn.RNN, x, y):
             if m.bidirectional
             else _count_rnn_cell(hidden_size, hidden_size, bias)
         )
-    # time unroll
-    total_ops *= num_steps
-    # batch_size
-    total_ops *= batch_size
+    total_ops *= evaluations
 
     m.total_ops += int(total_ops)
 
@@ -140,7 +132,7 @@ def count_gru(m: nn.GRU, x, y):
     hidden_size = m.hidden_size
     num_layers = m.num_layers
 
-    batch_size, num_steps = _batch_and_steps(m, x[0])
+    evaluations = _cell_evaluations(x[0])
 
     total_ops = 0
     if m.bidirectional:
@@ -154,10 +146,7 @@ def count_gru(m: nn.GRU, x, y):
             if m.bidirectional
             else _count_gru_cell(hidden_size, hidden_size, bias)
         )
-    # time unroll
-    total_ops *= num_steps
-    # batch_size
-    total_ops *= batch_size
+    total_ops *= evaluations
 
     m.total_ops += int(total_ops)
 
@@ -168,24 +157,23 @@ def count_lstm(m: nn.LSTM, x, y):
     input_size = m.input_size
     hidden_size = m.hidden_size
     num_layers = m.num_layers
+    proj_size = m.proj_size
+    stacked_size = proj_size or hidden_size  # the width a projected layer hands the next one
 
-    batch_size, num_steps = _batch_and_steps(m, x[0])
+    evaluations = _cell_evaluations(x[0])
 
     total_ops = 0
     if m.bidirectional:
-        total_ops += _count_lstm_cell(input_size, hidden_size, bias) * 2
+        total_ops += _count_lstm_cell(input_size, hidden_size, bias, proj_size) * 2
     else:
-        total_ops += _count_lstm_cell(input_size, hidden_size, bias)
+        total_ops += _count_lstm_cell(input_size, hidden_size, bias, proj_size)
 
     for _ in range(num_layers - 1):
         total_ops += (
-            _count_lstm_cell(hidden_size * 2, hidden_size, bias) * 2
+            _count_lstm_cell(stacked_size * 2, hidden_size, bias, proj_size) * 2
             if m.bidirectional
-            else _count_lstm_cell(hidden_size, hidden_size, bias)
+            else _count_lstm_cell(stacked_size, hidden_size, bias, proj_size)
         )
-    # time unroll
-    total_ops *= num_steps
-    # batch_size
-    total_ops *= batch_size
+    total_ops *= evaluations
 
     m.total_ops += int(total_ops)


### PR DESCRIPTION
## Summary

Charge a `PackedSequence` the cell evaluations it performs, and read `proj_size` when counting an LSTM.

Packing exists to skip the padding. The rules multiplied a step count by a batch size, which rebuilds exactly the rectangle that was skipped: a `pack_sequence` of lengths 7, 3 and 1 has `batch_sizes` `[3, 2, 2, 1, 1, 1, 1]` and performs 11 cell evaluations, while `7 × 3` charges 21. That sum *is* the evaluation count, so the two multiplications become one.

The same rewrite drops the `batch_first` branch. It chose which of the first two axes to read for the batch and which for the steps, and only their product was ever used — a product that is the same either way.

`nn.LSTM(proj_size=...)` projects the hidden state through `W_hr`, which narrows every recurrent matmul from `hidden_size` to `proj_size` and hands the next layer that width instead. `weight_hh_l0` is `(4 * hidden_size, proj_size)`, `weight_hr_l0` is `(proj_size, hidden_size)` and `weight_ih_l1` is `(4 * hidden_size, proj_size)`, doubled when bidirectional. The count now follows those shapes; before, a projected layer and an unprojected one reported the same number.

Deleted: the padded-rectangle reconstruction, and the `batch_first` axis-order branch it needed.

### Numbers

| layer | input | before | after |
| -- | -- | -- | -- |
| `nn.LSTM(10, 20)` | `pack_sequence` of 7, 3, 1 | 57,120 | 29,920 |
| `nn.RNN(10, 20)` | same | 13,860 | 7,260 |
| `nn.GRU(10, 20)` | same | 43,260 | 22,660 |
| `nn.LSTM(10, 20, proj_size=8)` | `(7, 3, 10)` | 57,120 | 40,320 |
| `nn.LSTM(10, 20)` | `(7, 3, 10)` | 57,120 | 57,120 |
| `nn.LSTM(10, 20)` | `(7, 10)` unbatched | 19,040 | 19,040 |

Every figure comes out a second way, through torch's own parameter shapes rather than through this formula: a weight's `numel()` is its multiply-accumulate count, so `nn.LSTM(10, 20, proj_size=8)` costs `800 + 640 + 160` matmul MACs per evaluation, plus the gate add, the two bias adds, the three ops of `c' = f * c + i * g` and the hadamard of `h'` — 1,920, times 21 evaluations.

### Boundaries

Measured rather than reasoned about. `enforce_sorted=False` and `pack_padded_sequence` produce the same `batch_sizes` and the same count. A packed batch of equal lengths still costs what its padded form costs, since the sum and the rectangle coincide there. A zero-length sequence never reaches the rule — torch refuses to pack one. `batch_first` is ignored for a packed input by torch and now by the rule as well.

Bidirectional is charged both directions at the same evaluation count, which torch's own output confirms: the packed output of an uneven batch through a bidirectional LSTM holds exactly `sum(batch_sizes)` rows.

Verified against the declared torch floor from that tag's own source: `RNNBase` carries `proj_size` in 1.8.0, validates it to `[0, hidden_size)`, and computes `real_hidden_size = proj_size if proj_size > 0 else hidden_size` — the same quantity under the same name.

No published Ultralytics figure is affected: no model YAML instantiates any RNN type.

## Validation

- Full suite: 20 passed before, 20 passed after; 36 local regression cases for this change, 26 of which fail without it.
- Both entry points: every case runs through `profile` and `profile_origin`.
- `ruff check` and `ruff format --check` clean at the repo's line length.
- No test code added to the commit.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧮 Improves recurrent neural network operation counting for packed, unbatched, bidirectional, and projected LSTM inputs.

### 📊 Key Changes

- Replaces separate batch-size and sequence-length handling with a unified cell-evaluation count.
- Correctly counts work for `PackedSequence` inputs using the sum of active sequence elements.
- Supports unbatched recurrent inputs without misinterpreting sequence length as batch size.
- Adds LSTM projection support through `proj_size`, including:
  - Projection-aware recurrent matrix dimensions.
  - Projection operations in the LSTM cell.
  - Correct input sizing between stacked LSTM layers.
- Applies the updated evaluation logic consistently to `RNN`, `GRU`, and `LSTM` counters.

### 🎯 Purpose & Impact

- ✅ Produces more accurate MACs/operation estimates for common PyTorch recurrent-layer configurations.
- 📦 Avoids overcounting padded work when using packed sequences.
- 🔄 Improves compatibility with unbatched inputs and projected LSTMs.
- 📈 Helps THOP users obtain more reliable model complexity and efficiency measurements.