### PR TITLE
Register the container and max-unpool types that compute nothing

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -73,6 +73,7 @@ register_hooks = {
     nn.AdaptiveMaxPool3d: zero_ops,
     nn.FractionalMaxPool2d: zero_ops,  # a max pool that picks its windows randomly still only selects
     nn.FractionalMaxPool3d: zero_ops,
+    nn.modules.pooling._MaxUnpoolNd: zero_ops,  # scattering into a larger zero tensor adds nothing
     nn.AvgPool1d: count_avgpool,
     nn.AvgPool2d: count_avgpool,
     nn.AvgPool3d: count_avgpool,
@@ -90,7 +91,13 @@ register_hooks = {
     nn.RNN: count_rnn,
     nn.GRU: count_gru,
     nn.LSTM: count_lstm,
+    # containers hold children and compute nothing themselves; they share no base but nn.Module
     nn.Sequential: zero_ops,
+    nn.ModuleList: zero_ops,
+    nn.ModuleDict: zero_ops,
+    nn.ParameterList: zero_ops,
+    nn.ParameterDict: zero_ops,
+    nn.Container: zero_ops,
     # layers that only move elements around: a view, a re-index or a permutation reads and writes each
     # element once and multiplies nothing. The elementwise activations that also reach no rule are left
     # warned about on purpose, because registering one asserts it is free and SiLU, Mish, GELU, GLU and

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -92,7 +92,6 @@ register_hooks = {
     nn.GRU: count_gru,
     nn.LSTM: count_lstm,
     # containers hold children and compute nothing themselves; they share no base but nn.Module.
-    # nn.Container is left out: it is deprecated into a plain nn.Module, so a subclass of it computes.
     nn.Sequential: zero_ops,
     nn.ModuleList: zero_ops,
     nn.ModuleDict: zero_ops,

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -91,13 +91,13 @@ register_hooks = {
     nn.RNN: count_rnn,
     nn.GRU: count_gru,
     nn.LSTM: count_lstm,
-    # containers hold children and compute nothing themselves; they share no base but nn.Module
+    # containers hold children and compute nothing themselves; they share no base but nn.Module.
+    # nn.Container is left out: it is deprecated into a plain nn.Module, so a subclass of it computes.
     nn.Sequential: zero_ops,
     nn.ModuleList: zero_ops,
     nn.ModuleDict: zero_ops,
     nn.ParameterList: zero_ops,
     nn.ParameterDict: zero_ops,
-    nn.Container: zero_ops,
     # layers that only move elements around: a view, a re-index or a permutation reads and writes each
     # element once and multiplies nothing. The elementwise activations that also reach no rule are left
     # warned about on purpose, because registering one asserts it is free and SiLU, Mish, GELU, GLU and


### PR DESCRIPTION
## Summary

Register the container types and the max-unpool family, both of which compute nothing.

`nn.Sequential` is already `zero_ops` precisely because a container holds children and computes nothing itself, and every module in the tree is asked for a rule whether or not it has a forward pass. `nn.ModuleList`, `nn.ModuleDict`, `nn.ParameterList` and `nn.ParameterDict` are containers of the same kind and were not registered, so a model holding its blocks in a `ModuleList` — the idiomatic shape when the forward order is not a plain sequence — was warned about for a class with no forward method at all. They share no base but `nn.Module`, so it is one key each.

`nn.Container` is deliberately not among them. Registering a type silences every subclass of it, which is what the MRO walk is for and is right for a concrete container; but `nn.Container` is deprecated into a plain `nn.Module` — "all of its functionality is now implemented in nn.Module" — so a subclass of it is a computing module rather than a container, and silencing it would hide exactly the work `report_missing` exists to surface.

`nn.MaxUnpool1d/2d/3d` place each input value into a larger zero tensor at an index the matching max pool recorded. That is a scatter with no arithmetic, the same shape as `nn.MaxPool2d` beside them. All three derive from `nn.modules.pooling._MaxUnpoolNd`, so one key covers the family — the move the dropout and padding families already use.

No count moves, by construction as well as by measurement: since zero-op rules stopped registering a hook, a type resolving to `zero_ops` and a type resolving to nothing both contribute 0. What changes is the warning. A red `[WARN]` about a layer that has nothing to count is what teaches a reader to ignore the warning, and `report_missing` is there for the third-party module that genuinely has no rule — which still gets one.

### Before and after

`profile(model, report_missing=True)` on a model holding one `nn.Conv2d(3, 3, 1)` in a `ModuleList`, and on `nn.MaxUnpool2d(2)` fed by its matching pool:

| | before | after |
| -- | -- | -- |
| ModuleList model | 576 MACs, 12 params, warns about `ModuleList` **and** the user's own class | same numbers, warns about the user's class only |
| the `nn.Sequential` equivalent | 576 MACs, 12 params, no warning | unchanged |
| `nn.MaxUnpool1d/2d/3d` | 0 MACs, warned about by both entry points | 0 MACs, no warning |

### Boundaries

Verified against the declared torch floor from that tag's own source: `torch/nn/modules/container.py` at v1.8.0 defines all five container classes, and `torch/nn/modules/pooling.py` at v1.8.0 defines `_MaxUnpoolNd` with the three unpool classes deriving from it.

`nn.ParameterList` and `nn.ParameterDict` hold Parameters rather than Modules; their contents are counted through `model.parameters()` and registering the container changes only which rule it resolves to. Measured: a model holding a `ParameterList` of 3 and a `ParameterDict` of 2 still reports 5 parameters through both entry points.

`_MaxUnpoolNd` has exactly three descendants today, none of which does arithmetic.

## Validation

- Full suite: 20 passed before, 20 passed after; 25 local regression cases for this change, 17 of which fail without it.
- Both entry points: every case runs through `profile` and `profile_origin`.
- A conv/norm/relu/pool model still reports 4,612, and a user module with no rule is still warned about — the two negative controls.
- `ruff check` and `ruff format --check` clean at the repo's line length.
- No test code added to the commit.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds zero-operation profiling support for unpooling layers and PyTorch container modules. ⚙️

### 📊 Key Changes

- Registers `nn.modules.pooling._MaxUnpoolNd` as a zero-operation layer.
- Adds zero-operation handling for:
  - `nn.ModuleList`
  - `nn.ModuleDict`
  - `nn.ParameterList`
  - `nn.ParameterDict`
- Documents that container modules hold child modules but perform no computations themselves.
- Keeps `nn.Sequential` classified as zero-operation.

### 🎯 Purpose & Impact

- ✅ Prevents unnecessary profiling warnings for supported PyTorch containers and unpooling layers.
- 📈 Improves the accuracy and completeness of operation-counting results by excluding modules that do not perform arithmetic.
- 🧩 Makes THOP more compatible with models that use modular layer containers or max-unpooling operations.
- 🚀 Users should see cleaner profiling output without affecting measured compute costs for the actual child layers.