### PR TITLE
Record why nn.AdaptiveLogSoftmaxWithLoss is left unregistered

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -57,7 +57,9 @@ register_hooks = {
     nn.LayerNorm: count_normalization,
     nn.GroupNorm: count_normalization,
     nn.PReLU: count_prelu,
-    # The softmax family shares no base, so each member is registered explicitly.
+    # The softmax family shares no base, so each member is registered explicitly. nn.AdaptiveLogSoftmaxWithLoss
+    # is left out: its forward takes the targets and computes only the clusters they route to, so its cost is
+    # not a function of the input shape. Its head and tail projections are nn.Linear children and count already.
     nn.Softmax: count_softmax,
     nn.LogSoftmax: count_softmax,
     nn.Softmin: count_softmax,


### PR DESCRIPTION
## Summary

`nn.AdaptiveLogSoftmaxWithLoss` reaches no rule and `report_missing=True` names it, which reads as a gap waiting for a formula. It is not one: `forward` takes the targets and runs only the projections of the cluster each row routes to, so the layer's cost is not a function of the input shape.

At one fixed `(8, 64)` input, the reported total moves by 3× with the target values alone — 6144 with every row in the head shortlist, 18176 with every row in the first cluster, 10112 with every row in the second. Even the figure its `nn.Linear` children already report is target-dependent, so there is no shape-derived total for a parent rule to add to. `log_prob` and `predict`, which do score every class for every row, take no target and are not what a forward hook sees.

This records the decision at the registry, next to the softmax entries it would otherwise sit among, in the same shape as the note already there for the elementwise activations. The head and tail projections keep being counted by `count_linear`, and the `report_missing` warning stays, which is the honest answer for a cost this package cannot derive.

## Validation

- No behaviour changes: a comment-only diff. A conv, batch-norm, ReLU and adaptive-average-pool model reports 4612.0 before and after, and the shipped tests pass.
- The three routing cases above were measured through both `profile` and `profile_origin` and match the children's own `count_linear` totals exactly: head `Linear(64, 12)` is 6144 over 8 rows, cluster 0 adds `Linear(64, 16)` and `Linear(16, 30)` for 12032, cluster 1 adds `Linear(64, 4)` and `Linear(4, 60)` for 3968.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Documents why `nn.AdaptiveLogSoftmaxWithLoss` is intentionally not registered for custom operation counting.

### 📊 Key Changes
- Clarifies that `nn.AdaptiveLogSoftmaxWithLoss` is excluded because its forward computation depends on target routing rather than only input shape.
- Notes that the module's `nn.Linear` head and tail projections are already counted through their child modules.
- Leaves existing explicit registrations for `nn.Softmax`, `nn.LogSoftmax`, and `nn.Softmin` unchanged.

### 🎯 Purpose & Impact
- Improves code clarity and preserves the rationale for the registration decision.
- Prevents future contributors from incorrectly adding an unsuitable standalone counter.
- Has no expected runtime or profiling behavior change; this is a documentation-only code comment update. 📝