### PR TITLE
Count what a local response norm and an Lp pool compute

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -59,7 +59,7 @@ register_hooks = {
     nn.LayerNorm: count_normalization,
     nn.GroupNorm: count_normalization,
     nn.LocalResponseNorm: count_lrn,
-    nn.CrossMapLRN2d: count_lrn,  # the legacy spelling, same arithmetic and same four arguments
+    nn.CrossMapLRN2d: count_lrn,  # the legacy spelling, same arithmetic
     nn.PReLU: count_prelu,
     # The softmax family shares no base, so each member is registered explicitly.
     nn.Softmax: count_softmax,

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -18,6 +18,8 @@ from thop.vision.basic_hooks import (
     count_convNd,
     count_convtNd,
     count_linear,
+    count_lp_pool,
+    count_lrn,
     count_multihead_attention,
     count_normalization,
     count_prelu,
@@ -56,6 +58,8 @@ register_hooks = {
     nn.modules.batchnorm._NormBase: count_normalization,
     nn.LayerNorm: count_normalization,
     nn.GroupNorm: count_normalization,
+    nn.LocalResponseNorm: count_lrn,
+    nn.CrossMapLRN2d: count_lrn,  # the legacy spelling, same arithmetic and same four arguments
     nn.PReLU: count_prelu,
     # The softmax family shares no base, so each member is registered explicitly.
     nn.Softmax: count_softmax,
@@ -79,6 +83,7 @@ register_hooks = {
     nn.AdaptiveAvgPool1d: count_adap_avgpool,
     nn.AdaptiveAvgPool2d: count_adap_avgpool,
     nn.AdaptiveAvgPool3d: count_adap_avgpool,
+    nn.modules.pooling._LPPoolNd: count_lp_pool,
     nn.Linear: count_linear,
     nn.Bilinear: count_bilinear,
     nn.Upsample: count_upsample,

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -126,24 +126,21 @@ def count_avgpool(m, x, y):
 
 def count_lp_pool(m, x, y):
     """Calculate and update the total operation count for an Lp pool layer."""
-    if abs(float(m.norm_type)) == float("inf"):  # torch coerces the norm, and "inf" reaches its max-pool path
-        return  # that path is a max pool over absolute values, which selects rather than computes
-    # nn.LPPool3d arrived after the torch 1.8 floor, so the three-dimensional case is the fall-through
-    dims = 1 if isinstance(m, nn.LPPool1d) else 2 if isinstance(m, nn.LPPool2d) else 3
+    if abs(float(m.norm_type)) == float("inf"):  # float() because torch accepts a string norm
+        return  # that norm is a max pool over absolute values, which selects rather than computes
+    dims = 1 if isinstance(m, nn.LPPool1d) else 2 if isinstance(m, nn.LPPool2d) else 3  # 3d postdates the floor
     kernel = (m.kernel_size,) * dims if isinstance(m.kernel_size, int) else m.kernel_size
     stride = kernel if m.stride is None else (m.stride,) * dims if isinstance(m.stride, int) else m.stride
     windows = 1
     for size, output, k, s in zip(x[0].shape[-dims:], y.shape[-dims:], kernel, stride):
         windows *= sum(min(i * s + k, size) - i * s for i in range(output))  # Lp pooling never pads
-    # one power per input and one add per input the windows read, then per output the window's divide, the
-    # multiply by the sign, the multiply by the kernel area and the p-th root
+    # a power per input, an add per input a window reads, then the divide, both multiplies and the root per output
     m.total_ops += x[0].numel() + l_prod(x[0].shape[:-dims]) * windows + 4 * y.numel()
 
 
 def count_lrn(m, x, y):
     """Calculate and update the total operation count for a local response normalization layer."""
-    # one square per element and `size` window adds, then the window's divide, the alpha multiply, the k add,
-    # the beta power and the final divide
+    # a square per element, `size` window adds, then the divide, the alpha multiply, the k add, a power, a divide
     m.total_ops += x[0].numel() * (m.size + 6)
 
 

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -124,6 +124,29 @@ def count_avgpool(m, x, y):
     m.total_ops += l_prod(x[0].shape[:-dims]) * windows + y.numel()  # one add per input, one divide per output
 
 
+def count_lp_pool(m, x, y):
+    """Calculate and update the total operation count for an Lp pool layer."""
+    if abs(float(m.norm_type)) == float("inf"):  # torch coerces the norm, and "inf" reaches its max-pool path
+        return  # that path is a max pool over absolute values, which selects rather than computes
+    # nn.LPPool3d arrived after the torch 1.8 floor, so the three-dimensional case is the fall-through
+    dims = 1 if isinstance(m, nn.LPPool1d) else 2 if isinstance(m, nn.LPPool2d) else 3
+    kernel = (m.kernel_size,) * dims if isinstance(m.kernel_size, int) else m.kernel_size
+    stride = kernel if m.stride is None else (m.stride,) * dims if isinstance(m.stride, int) else m.stride
+    windows = 1
+    for size, output, k, s in zip(x[0].shape[-dims:], y.shape[-dims:], kernel, stride):
+        windows *= sum(min(i * s + k, size) - i * s for i in range(output))  # Lp pooling never pads
+    # one power per input and one add per input the windows read, then per output the window's divide, the
+    # multiply by the sign, the multiply by the kernel area and the p-th root
+    m.total_ops += x[0].numel() + l_prod(x[0].shape[:-dims]) * windows + 4 * y.numel()
+
+
+def count_lrn(m, x, y):
+    """Calculate and update the total operation count for a local response normalization layer."""
+    # one square per element and `size` window adds, then the window's divide, the alpha multiply, the k add,
+    # the beta power and the final divide
+    m.total_ops += x[0].numel() * (m.size + 6)
+
+
 def count_adap_avgpool(m, x, y):
     """Calculate and update the total operation counts for an AdaptiveAvgPool layer from the windows it pools."""
     # the windows nn.AdaptiveAvgPool* actually slices, per dimension: output j spans


### PR DESCRIPTION
## Summary

`nn.LocalResponseNorm`, `nn.CrossMapLRN2d` and the `nn.LPPool1d/2d/3d` family reached no rule, so each reported 0.0 MACs while `report_missing=True` named it. Both do real per-element work over a window, and `count_normalization` is the wrong shape for them: it is `2 * numel` and reads no window at all.

`count_lrn` charges one square per element and the `size` window adds, then the window's divide, the alpha multiply, the k add, the beta power and the final divide. torch zero-pads the channel axis by `size // 2` and `(size - 1) // 2` and runs a stride-1 pool over it, so every window is exactly `size` wide and the total is `numel * (size + 6)`. `nn.CrossMapLRN2d` is the same arithmetic over the same four arguments and shares the rule.

`count_lp_pool` reaches all three classes through the `_LPPoolNd` base they share, the way the padding, dropout and unpool families already do. It charges one power per input and one add per input its windows read, then the pool's divide, the multiply by the sign, the multiply by the kernel area and the p-th root for every output. `nn.LPPool` never pads, which is why its window loop has no padding term and does not go through `count_avgpool`. At `norm_type = ±inf` torch dispatches to `max_pool` over absolute values, so the rule returns early and reports zero, as `nn.MaxPool2d` already does.

`nn.FractionalMaxPool2d` and `nn.FractionalMaxPool3d` already resolve to `zero_ops` and are untouched.

## Validation

- `nn.LocalResponseNorm(5)` over a `(1, 8, 16, 16)` input reports 22528 where it reported 0.0, and `nn.LPPool2d(2, 2)` over the same input reports 6144. Verified through both `profile` and `profile_origin`.
- Every expected count is written as its own enumeration rather than as a literal. The LRN figure is reached twice: once from the seven terms above and once by handing the same zero-padded stride-1 window to the shipped `count_avgpool`, which agree at `size` 2, 3 and 5.
- Covered: `stride=None`, mixed tuple kernels and strides, `ceil_mode=True` windows clipped by the input bound, unbatched inputs, rank-3 inputs, fractional and negative `norm_type`, and a `norm_type` torch coerces from a string.
- Eight `nn.AvgPool` configurations are pinned as (window contributions, output elements) and unchanged, since the LRN cross-check leans on that rule.
- Neither rule belongs in the `stride=` estimator's `fixed_ops`: both costs are proportional to the input element count. A conv model ending in either reports the same total directly and through `stride=32` for non-overlapping windows; the overlapping case is 0.6% low, which is the clipped last window and not this change — `nn.AvgPool2d(3, stride=2)` with the same geometry is already 0.5% low on current main.
- A conv, batch-norm, ReLU and adaptive-average-pool model reports 4612.0 before and after, and the shipped tests pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds THOP operation-counting support for local response normalization and Lp pooling layers.

### 📊 Key Changes
- Registers `nn.LocalResponseNorm` and legacy `nn.CrossMapLRN2d` with a new LRN counting hook.
- Registers the `_LPPoolNd` family with a new Lp pooling counting hook covering 1D, 2D, and 3D variants.
- Accounts for pooling windows, norm type behavior, and per-element normalization or pooling operations.

### 🎯 Purpose & Impact
- Improves FLOP/operation estimates for models using LRN and Lp pooling layers.
- Supports accurate profiling across current and legacy PyTorch layer names.
- Lp pooling with infinite norm is treated as a selection-based max-pooling path and contributes no counted arithmetic operations.