### PR TITLE
Register the embedding lookup and record why the bag is not counted

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -17,6 +17,7 @@ from thop.vision.basic_hooks import (
     count_bilinear,
     count_convNd,
     count_convtNd,
+    count_embedding,
     count_linear,
     count_multihead_attention,
     count_normalization,
@@ -104,9 +105,8 @@ register_hooks = {
     nn.PixelShuffle: zero_ops,
     nn.PixelUnshuffle: zero_ops,
     nn.ChannelShuffle: zero_ops,
-    # max_norm norms the touched rows and rescales only those over the limit, so its cost follows the data.
     # nn.EmbeddingBag stays unregistered: padding_idx drops entries and repeated offsets make empty bags.
-    nn.Embedding: zero_ops,
+    nn.Embedding: count_embedding,
 }
 
 if _HOOK_TAKES_KWARGS:

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -104,6 +104,9 @@ register_hooks = {
     nn.PixelShuffle: zero_ops,
     nn.PixelUnshuffle: zero_ops,
     nn.ChannelShuffle: zero_ops,
+    # max_norm norms the touched rows and rescales only those over the limit, so its cost follows the data.
+    # nn.EmbeddingBag stays unregistered: padding_idx drops entries and repeated offsets make empty bags.
+    nn.Embedding: zero_ops,
 }
 
 if _HOOK_TAKES_KWARGS:

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -17,7 +17,6 @@ from thop.vision.basic_hooks import (
     count_bilinear,
     count_convNd,
     count_convtNd,
-    count_embedding,
     count_linear,
     count_multihead_attention,
     count_normalization,
@@ -97,16 +96,18 @@ register_hooks = {
     # warned about on purpose, because registering one asserts it is free and SiLU, Mish, GELU, GLU and
     # Hardswish each multiply per element, so they want formulas rather than a blanket entry. nn.Fold is
     # out because it sums OVERLAPPING blocks, and an addition per input over a window is the work
-    # count_adap_avgpool charges rather than something a view does.
+    # count_adap_avgpool charges rather than something a view does. An nn.Embedding gather is one of these: its
+    # max_norm rescale is left uncounted, being data-dependent on which rows the indices push over the limit.
+    # nn.EmbeddingBag stays out entirely, since it really does reduce each bag, and how many adds that takes is
+    # not a function of shape either: padding_idx entries drop out and repeated offsets make empty bags.
     nn.Identity: zero_ops,
+    nn.Embedding: zero_ops,
     nn.Flatten: zero_ops,
     nn.Unflatten: zero_ops,
     nn.Unfold: zero_ops,
     nn.PixelShuffle: zero_ops,
     nn.PixelUnshuffle: zero_ops,
     nn.ChannelShuffle: zero_ops,
-    # nn.EmbeddingBag stays unregistered: padding_idx drops entries and repeated offsets make empty bags.
-    nn.Embedding: count_embedding,
 }
 
 if _HOOK_TAKES_KWARGS:

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -17,6 +17,7 @@ from thop.vision.basic_hooks import (
     count_bilinear,
     count_convNd,
     count_convtNd,
+    count_embedding,
     count_linear,
     count_multihead_attention,
     count_normalization,
@@ -96,18 +97,19 @@ register_hooks = {
     # warned about on purpose, because registering one asserts it is free and SiLU, Mish, GELU, GLU and
     # Hardswish each multiply per element, so they want formulas rather than a blanket entry. nn.Fold is
     # out because it sums OVERLAPPING blocks, and an addition per input over a window is the work
-    # count_adap_avgpool charges rather than something a view does. An nn.Embedding gather is one of these: its
-    # max_norm rescale is left uncounted, being data-dependent on which rows the indices push over the limit.
-    # nn.EmbeddingBag stays out entirely, since it really does reduce each bag, and how many adds that takes is
-    # not a function of shape either: padding_idx entries drop out and repeated offsets make empty bags.
+    # count_adap_avgpool charges rather than something a view does.
     nn.Identity: zero_ops,
-    nn.Embedding: zero_ops,
     nn.Flatten: zero_ops,
     nn.Unflatten: zero_ops,
     nn.Unfold: zero_ops,
     nn.PixelShuffle: zero_ops,
     nn.PixelUnshuffle: zero_ops,
     nn.ChannelShuffle: zero_ops,
+    # a gather, so it belongs with the block above, but max_norm keeps it out of a blanket zero: that rescale is
+    # real work and count_embedding warns rather than assert it away, the way count_upsample does for a mode it has
+    # no cost for. nn.EmbeddingBag stays unregistered, since it really does reduce each bag and how many adds that
+    # takes is not a function of shape either: padding_idx entries drop out and repeated offsets make empty bags.
+    nn.Embedding: count_embedding,
 }
 
 if _HOOK_TAKES_KWARGS:

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -23,6 +23,12 @@ def zero_ops(m, x, y):
     m.total_ops += calculate_zero_ops()
 
 
+def count_embedding(m, x, y):
+    """Charge nothing for an embedding gather, warning when max_norm makes that incomplete."""
+    if m.max_norm is not None:  # it renormalizes only the rows the indices push over the limit, so data decides
+        logging.getLogger(__name__).warning("max_norm renormalization is not counted")
+
+
 def count_convNd(m: _ConvNd, x, y: torch.Tensor):
     """Calculate and add the number of convolutional operations (FLOPs) for a ConvNd layer to the model's total ops."""
     x = x[0]

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -23,12 +23,6 @@ def zero_ops(m, x, y):
     m.total_ops += calculate_zero_ops()
 
 
-def count_embedding(m, x, y):
-    """Count an embedding lookup, which copies weight rows and multiplies nothing."""
-    if m.max_norm is not None:  # it rescales only the rows over the limit, so the cost follows the data
-        logging.getLogger(__name__).warning("max_norm renormalization is not counted")
-
-
 def count_convNd(m: _ConvNd, x, y: torch.Tensor):
     """Calculate and add the number of convolutional operations (FLOPs) for a ConvNd layer to the model's total ops."""
     x = x[0]

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -23,6 +23,12 @@ def zero_ops(m, x, y):
     m.total_ops += calculate_zero_ops()
 
 
+def count_embedding(m, x, y):
+    """Count an embedding lookup, which copies weight rows and multiplies nothing."""
+    if m.max_norm is not None:  # it rescales only the rows over the limit, so the cost follows the data
+        logging.getLogger(__name__).warning("max_norm renormalization is not counted")
+
+
 def count_convNd(m: _ConvNd, x, y: torch.Tensor):
     """Calculate and add the number of convolutional operations (FLOPs) for a ConvNd layer to the model's total ops."""
     x = x[0]


### PR DESCRIPTION
## Summary

A default `nn.Embedding` is a weight-row gather: every output element is a copy of a weight element, with no arithmetic. It reached no rule, so `report_missing=True` named it next to layers that really are uncounted. It joins the block of layers that only move elements around.

`max_norm` renormalizes the touched rows in place, and how much arithmetic that runs is not derivable: torch takes a norm per unique row the indices touch and rescales only the rows over the limit. With `max_norm=0.5` and row norms `[1.6872, 2.4027, 1.3847, 1.6895, ...]`, touching rows `{0, 0, 3}` left rows 0 and 3 at exactly 0.5 and nothing else; with `max_norm=100.0` the same call rescaled no row at all. Recovering the count would mean a `.unique()` on the index tensor inside the hook, which would make this the first rule to read tensor values rather than shapes and module attributes.

So the rule charges nothing and warns instead, the way `count_upsample` already does for an interpolation mode it has no cost for. A plain `zero_ops` entry would have turned a visible gap into a silent one: before this change a `max_norm` embedding was at least named by `report_missing`.

`nn.EmbeddingBag` stays unregistered. It really does sum or average each bag, so `zero_ops` would be wrong, but no rule reading only shapes can say how many adds ran: `padding_idx` entries drop out of the reduction, and repeated offsets make empty bags. A `gathered * embedding_dim - y.numel()` count reports -4 for a two-row input with offsets `[0, 2, 2]`.

## Validation

- `nn.Embedding(10, 4)` over `torch.arange(6)` reports `(0.0, 40.0)` and is no longer named by `report_missing`, through both `profile` and `profile_origin`.
- No class in `torch.nn` subclasses `nn.Embedding`, and `nn.EmbeddingBag` is not one either, so the entry cannot reach anything else through the MRO walk.
- `nn.EmbeddingBag` is still named in all three modes, and the measurements above are pinned as tests, including that a `padding_idx` mean equals the mean of the non-padding rows alone.
- A conv, batch-norm, ReLU and adaptive-average-pool model reports 4612.0 before and after, and the shipped tests pass.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds FLOPs profiling support for `nn.Embedding` layers while warning that `max_norm` renormalization is not counted. ⚡

### 📊 Key Changes

- Registered `nn.Embedding` with a new `count_embedding` operation counter.
- Treats embedding lookups as zero-cost gather operations for profiling purposes.
- Emits a warning when `max_norm` is enabled, since its data-dependent row renormalization is excluded.
- Leaves `nn.EmbeddingBag` unsupported because its reduction cost depends on padding, offsets, and repeated indices.

### 🎯 Purpose & Impact

- Improves THOP compatibility with models that use standard PyTorch embedding layers. 📈
- Prevents embedding lookups from being incorrectly reported as unsupported or contributing misleading FLOPs.
- Makes profiling results more transparent by warning users about uncounted `max_norm` work.
- Users relying on `nn.EmbeddingBag` or detailed embedding renormalization costs should continue to treat those operations as unprofiled.