### PR TITLE
Count the attention matrix products of an F.scaled_dot_product_attention block

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ A ViT-style block that computes attention through `F.scaled_dot_product_attentio
 ```python
 import torch
 import torch.nn.functional as F
+from torch import nn
+
 from thop import profile
 from thop.vision.basic_hooks import count_scaled_dot_product_attention
-from torch import nn
 
 
 class Attention(nn.Module):

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ print(f"Custom MACs: {macs}, Parameters: {params}")
 
 ### Attention Built from `F.scaled_dot_product_attention`
 
-A ViT-style block that computes attention through `F.scaled_dot_product_attention` calls no module thop can hook: the qkv/output projections are still counted as ordinary `nn.Linear` children, but the query-key and attention-value matrix products are not. `count_scaled_dot_product_attention` prices that missing term for a self-attention block; register it against the block's own class the same way as any other custom rule:
+A ViT-style block using PyTorch 2.0+ that computes attention through `F.scaled_dot_product_attention` calls no module thop can hook: the qkv/output projections are still counted as ordinary `nn.Linear` children, but the query-key and attention-value matrix products are not. `count_scaled_dot_product_attention` prices that missing term for a self-attention block; register it against the block's own class the same way as any other custom rule:
 
 ```python
 import torch

--- a/README.md
+++ b/README.md
@@ -85,6 +85,41 @@ print(f"Custom MACs: {macs}, Parameters: {params}")
 # Expected output: Custom MACs: 89915392.0, Parameters: 1792.0
 ```
 
+### Attention Built from `F.scaled_dot_product_attention`
+
+A ViT-style block that computes attention through `F.scaled_dot_product_attention` calls no module thop can hook: the qkv/output projections are still counted as ordinary `nn.Linear` children, but the query-key and attention-value matrix products are not. `count_scaled_dot_product_attention` prices that missing term for a self-attention block; register it against the block's own class the same way as any other custom rule:
+
+```python
+import torch
+import torch.nn.functional as F
+from thop import profile
+from thop.vision.basic_hooks import count_scaled_dot_product_attention
+from torch import nn
+
+
+class Attention(nn.Module):
+    def __init__(self, dim=384, num_heads=6):
+        super().__init__()
+        self.num_heads = num_heads
+        self.qkv = nn.Linear(dim, dim * 3)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x):
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads).permute(2, 0, 3, 1, 4)
+        q, k, v = qkv.unbind(0)
+        x = F.scaled_dot_product_attention(q, k, v).transpose(1, 2).reshape(B, N, C)
+        return self.proj(x)
+
+
+model = Attention(384, 6)
+inputs = (torch.randn(1, 256, 384),)
+macs, params = profile(model, inputs=inputs, custom_ops={Attention: count_scaled_dot_product_attention})
+
+print(f"MACs: {macs}, Parameters: {params}")
+# Expected output: MACs: 201326592.0, Parameters: 591360.0
+```
+
 ### Improve Output Readability
 
 Use `clever_format()` to convert raw counts into human-readable values:

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -197,3 +197,14 @@ def count_multihead_attention(m: nn.MultiheadAttention, x, y):
     attention = 2 * tgt_len * attended * m.embed_dim
     softmax = calculate_softmax(batch_size * m.num_heads * tgt_len, attended)
     m.total_ops += batch_size * (projections + attention) + softmax
+
+
+def count_scaled_dot_product_attention(m, x, y):
+    """Count the query-key and attention-value matrix products of an F.scaled_dot_product_attention block.
+
+    Registered per class via custom_ops: the functional call has no owning module for add_hooks to reach, while the
+    block's own qkv/output nn.Linear children are already counted. Assumes self-attention, reading the shared token
+    count from the block's own input; omits softmax, which needs num_heads and no generic block guarantees one.
+    """
+    tokens, dim = x[0].shape[-2:]
+    m.total_ops += l_prod(x[0].shape[:-2]) * 2 * tokens * tokens * dim


### PR DESCRIPTION
## Summary

Adds `count_scaled_dot_product_attention`, a counting rule for self-attention blocks built from `F.scaled_dot_product_attention` (the qkv-Linear + SDPA + output-Linear pattern used by `timm` and DINOv2/DINOv3-style vision transformers). The functional call has no owning module, so `add_hooks` never reaches it, and the block's own MACs come back short by the whole O(N²) attention term while the qkv/output `nn.Linear` children are still counted correctly.

The new rule is not auto-registered — there is no fixed torch type to key it to, since this attention shape is always a caller-defined class — so it is meant to be wired up per class through the existing `custom_ops` parameter, the same mechanism `README.md` already documents for third-party modules. README gains a short section showing that usage.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds support for counting the attention matrix products performed by `F.scaled_dot_product_attention` in custom self-attention blocks.

### 📊 Key Changes
- Adds `count_scaled_dot_product_attention` to `thop/vision/basic_hooks.py`.
- Counts query-key and attention-value matrix products while relying on existing hooks for linear projections.
- Documents registration and usage with a ViT-style attention example in `README.md`.

### 🎯 Purpose & Impact
- Enables more complete MAC estimates for attention implementations using PyTorch’s functional scaled dot-product API.
- Provides a reusable custom operation rule for blocks that cannot be hooked at the functional call level.
- Improves profiling accuracy for self-attention models, while intentionally omitting softmax operations due to unavailable generic block metadata.