### PR TITLE
Let profile_origin count a composite module's own rule

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -224,10 +224,11 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=
         verbose = True
 
     def add_hooks(m):
-        if (list(m.children()) and not isinstance(m, nn.MultiheadAttention)) or m in handler_collection:
+        m_type = type(m)
+        has_own_rule = any(t in custom_ops or t in register_hooks for t in m_type.__mro__)
+        if (list(m.children()) and not has_own_rule) or m in handler_collection:
             return
 
-        m_type = type(m)
         fn = _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 
         if "total_ops" in m.__dict__ or "total_ops" in m._buffers:


### PR DESCRIPTION
## Summary

`profile_origin()`'s `add_hooks` skipped every module with children unless it was exactly `nn.MultiheadAttention` — a narrow special case for one built-in type. Any other composite type with its own rule, such as a caller's own `custom_ops` rule on a composite class, was silently dropped by `profile_origin()` while `profile()` counted it correctly, so the two exported entry points could disagree on the same model.

The skip now asks whether the module's type resolves to a rule at all — the same MRO walk `_resolve_rule` already does over `custom_ops` and `register_hooks` — rather than naming one type. A composite with no rule of its own (the common case: a model's own top-level wrapper class) is still skipped silently, exactly as before.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves THOP profiling so custom operation handlers are correctly applied to container modules and inherited module types. 🛠️

### 📊 Key Changes

- Detects whether a module or any class in its inheritance hierarchy has a custom profiling rule.
- Prevents modules with registered handlers from being skipped merely because they contain child modules.
- Reuses the module type lookup earlier in hook registration.
- Replaces the previous special-case handling for `nn.MultiheadAttention` with a more general handler-based approach.

### 🎯 Purpose & Impact

- ✅ Ensures custom operation counts are used for supported parent or composite modules.
- 📈 Improves profiling accuracy for user-defined layers and modules with inherited handlers.
- 🧩 Makes hook registration more flexible and reduces reliance on module-specific exceptions.
- 🔄 Existing profiling behavior remains unchanged for composite modules without custom handlers.