### PR TITLE
Register DistributedDataParallel as a zero-op process wrapper

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -91,6 +91,10 @@ register_hooks = {
     nn.GRU: count_gru,
     nn.LSTM: count_lstm,
     nn.Sequential: zero_ops,
+    # a process wrapper, not a container: it runs the wrapped module in place and adds gradient
+    # synchronization, which the package does not count. The wrapped module is an ordinary submodule
+    # that add_hooks already reaches on its own.
+    nn.parallel.DistributedDataParallel: zero_ops,
     # layers that only move elements around: a view, a re-index or a permutation reads and writes each
     # element once and multiplies nothing. The elementwise activations that also reach no rule are left
     # warned about on purpose, because registering one asserts it is free and SiLU, Mish, GELU, GLU and


### PR DESCRIPTION
## Summary

`DistributedDataParallel` reached no counting rule, so `profile(ddp_model, report_missing=True)` warned about a wrapper that contributes nothing rather than one that genuinely has no rule to give it. DDP runs the wrapped module in place and adds gradient synchronization, which the package does not count; the wrapped module's own hooks already fire normally.

Registers `nn.parallel.DistributedDataParallel: zero_ops`, verified on a single-process gloo group: the total matches profiling the unwrapped module exactly.

`nn.DataParallel` is a different mechanism — it replicates the module across devices, so the modules that execute may not be the ones hooked — and is left for separate measurement on multi-GPU hardware.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds support for profiling models wrapped with PyTorch’s `DistributedDataParallel` without counting its synchronization overhead.

### 📊 Key Changes
- Registers `nn.parallel.DistributedDataParallel` as a zero-operation wrapper in `thop/profile.py`.
- Treats the wrapper as a process-management layer rather than a computational module.
- Ensures THOP continues profiling the wrapped model’s submodules through existing hook logic.
- Excludes gradient synchronization and communication overhead from operation counts.

### 🎯 Purpose & Impact
- ✅ Enables more reliable FLOPs and parameter profiling for distributed and multi-GPU models.
- 🚀 Prevents unnecessary warnings or incorrect operation counts when using `DistributedDataParallel`.
- 🔍 Keeps profiling focused on the model’s actual neural network computation, not distributed training infrastructure.