### PR TITLE
Reject a total_ops name a module already owns instead of misreading it

### DIFF
--- a/thop/profile.py
+++ b/thop/profile.py
@@ -194,11 +194,22 @@ def _parents_first(roots):
 
 
 def _displace_total_ops(m):
-    """Temporarily remove a caller-owned `total_ops` attribute or buffer."""
+    """Temporarily remove a caller-owned `total_ops` buffer or attribute; reject a name thop cannot borrow."""
+    for cls in type(m).__mro__:
+        attr = vars(cls).get("total_ops")
+        if attr is not None and hasattr(attr, "__set__"):
+            raise TypeError(
+                f"{m!s} defines total_ops as a {cls.__name__} attribute; thop needs that name to profile it."
+            )
+    if "total_ops" in m._parameters:
+        raise TypeError(f"{m!s} already has a total_ops parameter; thop needs that name to profile it.")
+    if "total_ops" in m._modules:
+        raise TypeError(f"{m!s} already has a total_ops child module; thop needs that name to profile it.")
     displaced = [(store, store["total_ops"]) for store in (m._buffers, m.__dict__) if "total_ops" in store]
-    logging.warning(f"{m!s} already has a .total_ops; it is shadowed while profiling and restored after.")
-    for store, _ in displaced:
-        del store["total_ops"]
+    if displaced:
+        logging.warning(f"{m!s} already has a .total_ops; it is shadowed while profiling and restored after.")
+        for store, _ in displaced:
+            del store["total_ops"]
     return displaced
 
 
@@ -230,8 +241,9 @@ def profile_origin(model, inputs, custom_ops=None, verbose=True, report_missing=
         m_type = type(m)
         fn = _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 
-        if "total_ops" in m.__dict__ or "total_ops" in m._buffers:
-            displaced_collection[m] = _displace_total_ops(m)
+        displaced = _displace_total_ops(m)
+        if displaced:
+            displaced_collection[m] = displaced
         # register_buffer discards this flag; restore it without requiring the newer persistent= argument.
         non_persistent = "total_ops" in m._non_persistent_buffers_set
         m.register_buffer("total_ops", torch.zeros(1, dtype=default_dtype))
@@ -297,8 +309,9 @@ def profile(
         m_type = type(m)
         fn = _resolve_rule(m_type, custom_ops, types_collection, verbose, report_missing)
 
-        if "total_ops" in m.__dict__ or "total_ops" in m._buffers:
-            displaced_collection[m] = _displace_total_ops(m)
+        displaced = _displace_total_ops(m)
+        if displaced:
+            displaced_collection[m] = displaced
         # a plain int attribute, not a float64 buffer: buffer reads go through nn.Module.__getattr__ and every
         # hook would allocate a tensor per call, which dominates profiling cost on module-heavy models.
         # Written straight into __dict__ (mirroring the teardown below) to skip nn.Module.__setattr__.

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -207,16 +207,15 @@ def _parents_first(roots):
 
 def _displace_total_ops(m):
     """Temporarily remove a caller-owned `total_ops` buffer or attribute; reject a name thop cannot borrow."""
-    for cls in type(m).__mro__:
-        attr = vars(cls).get("total_ops")
-        if attr is not None and hasattr(attr, "__set__"):
-            raise TypeError(
-                f"{m!s} defines total_ops as a {cls.__name__} attribute; thop needs that name to profile it."
-            )
-    if "total_ops" in m._parameters:
-        raise TypeError(f"{m!s} already has a total_ops parameter; thop needs that name to profile it.")
-    if "total_ops" in m._modules:
-        raise TypeError(f"{m!s} already has a total_ops child module; thop needs that name to profile it.")
+    kind = None
+    if any(hasattr(vars(c).get("total_ops"), "__set__") for c in type(m).__mro__):
+        kind = "data descriptor"  # no per-instance value to displace, and the hook's writes never reach the total
+    elif "total_ops" in m._parameters:
+        kind = "parameter"  # displacing it would come back as a smaller parameter count
+    elif "total_ops" in m._modules:
+        kind = "child module"  # displacing it would come back as a dropped subtree
+    if kind:
+        raise TypeError(f"{m!s} owns total_ops as a {kind}; thop needs that name to profile it.")
     displaced = [(store, store["total_ops"]) for store in (m._buffers, m.__dict__) if "total_ops" in store]
     if displaced:
         logging.warning(f"{m!s} already has a .total_ops; it is shadowed while profiling and restored after.")


### PR DESCRIPTION
## Summary

`_displace_total_ops` only ever inspected `__dict__` and `_buffers`, so a `total_ops` parameter, child module, or class-level property was never detected. `profile()` and `profile_origin()` went on to write into or read from the colliding name anyway, surfacing as three different torch-internal messages depending on entry point and module shape — or, for a class-level property, no error at all: `profile()`'s counting hook writes through the property while the final MAC sum reads straight from `__dict__`, which the property's writes never touch, so the module silently contributes 0 MACs with no signal, even under `report_missing=True`.

Displacing a parameter or child module the way a buffer is displaced would answer with a quietly smaller parameter count or a dropped subtree, and a property has no per-instance value to displace at all — raising is the only outcome that doesn't misreport. `_displace_total_ops` now checks `type(m).__mro__` for a data descriptor and the module's own `_parameters`/`_modules` before touching anything, and raises one explicit `TypeError` naming `total_ops` and the module for all three cases. The existing buffer/plain-attribute displace-and-restore path is unchanged.

`profile_origin`'s own has-children skip still keeps it from reaching a composite module holding one of these collisions — that skip is a separate, pre-existing mechanism, unrelated to this fix, and is already being generalized by a separate, unmerged change (#168).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛡️ Strengthens `thop` profiling by safely handling modules that already use the `total_ops` name.

### 📊 Key Changes

- Detects conflicting `total_ops` definitions before profiling, including:
  - Data descriptors
  - Parameters
  - Child modules
- Raises a clear `TypeError` when `total_ops` cannot be safely borrowed.
- Continues to temporarily displace and restore existing `total_ops` attributes or buffers.
- Avoids unnecessary bookkeeping when no conflicting attribute exists.
- Applies the improved handling consistently across both hook-registration paths.

### 🎯 Purpose & Impact

- ✅ Prevents profiling from silently corrupting parameters, child modules, or descriptor-backed values.
- 🔍 Provides clearer error messages for unsupported module designs.
- 🔄 Preserves user-defined `total_ops` values after profiling when they can be safely displaced.
- ⚡ Reduces unnecessary overhead for modules without existing `total_ops` attributes.