### PR TITLE
Release 2.1.6

### DIFF
--- a/thop/__init__.py
+++ b/thop/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "2.1.5"
+__version__ = "2.1.6"
 
 import torch
 


### PR DESCRIPTION
Ships the six fixes merged since 2.1.5, which are on `main` but unreleased — PyPI is still at 2.1.5, so nothing downstream can consume them yet.

| PR | Fix |
| -- | -- |
| #160 | Packed sequences were charged the padded rectangle packing exists to avoid (packed LSTM 57,120 → 29,920); `proj_size` was ignored entirely |
| #167 | A quadratic `custom_ops` rule was extrapolated affinely by the `stride=` path — **36.4% low** |
| #168 | `profile_origin` silently dropped a custom rule on any composite module (4,096 vs 16,441) |
| #171 | A `total_ops` property made `profile()` return **0.0 MACs silently**, even under `report_missing` |
| #161 | `ModuleList`/`ParameterList` — classes with no `forward` — drew false missing-rule warnings |
| #165 | `nn.Embedding` drew a false missing-rule warning |

**Why now:** `ultralytics/ultralytics` needs #167 to count YOLO12 area-attention correctly. Without it a quadratic custom rule is extrapolated from a stride-sized sample and lands ~97% low on the attention term; with it, the attention count matches `torch.utils.flop_counter`'s `aten.bmm` figure exactly. That PR pins `ultralytics-thop>=2.1.6`, so it cannot install until this releases.

Merging this to `main` triggers `publish.yml`: tag `v2.1.6`, GitHub release, PyPI publish, SBOM, Slack.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🚀 Bumps the THOP package version from **2.1.5** to **2.1.6**.

### 📊 Key Changes

- Updated `thop.__version__` in `thop/__init__.py`.
- No functional or API changes are included in this PR.

### 🎯 Purpose & Impact

- 📦 Publishes a new patch release for package versioning and distribution.
- ✅ Users can identify installations as **THOP 2.1.6**.
- 🔒 Existing model profiling behavior remains unchanged.