### PR TITLE
Count SiLU and GELU as real work instead of reporting them as free

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,21 +110,21 @@ The following detection models were profiled at 640 × 640 from their fused arch
 
 | Model                                                                  | size<br><sup>(pixels)</sup> | params<br><sup>(M)</sup> | MACs<br><sup>(B)</sup> |
 | ---------------------------------------------------------------------- | --------------------------- | ------------------------ | ---------------------- |
-| [YOLOv8n](https://platform.ultralytics.com/ultralytics/yolov8/yolov8n) | 640                         | 3.15                     | 4.37                   |
-| [YOLOv8s](https://platform.ultralytics.com/ultralytics/yolov8/yolov8s) | 640                         | 11.16                    | 14.30                  |
-| [YOLOv8m](https://platform.ultralytics.com/ultralytics/yolov8/yolov8m) | 640                         | 25.89                    | 39.47                  |
-| [YOLOv8l](https://platform.ultralytics.com/ultralytics/yolov8/yolov8l) | 640                         | 43.67                    | 82.57                  |
-| [YOLOv8x](https://platform.ultralytics.com/ultralytics/yolov8/yolov8x) | 640                         | 68.20                    | 128.90                 |
-| [YOLO11n](https://platform.ultralytics.com/ultralytics/yolo11/yolo11n) | 640                         | 2.62                     | 3.24                   |
-| [YOLO11s](https://platform.ultralytics.com/ultralytics/yolo11/yolo11s) | 640                         | 9.44                     | 10.73                  |
-| [YOLO11m](https://platform.ultralytics.com/ultralytics/yolo11/yolo11m) | 640                         | 20.09                    | 33.99                  |
-| [YOLO11l](https://platform.ultralytics.com/ultralytics/yolo11/yolo11l) | 640                         | 25.34                    | 43.46                  |
-| [YOLO11x](https://platform.ultralytics.com/ultralytics/yolo11/yolo11x) | 640                         | 56.92                    | 97.45                  |
-| [YOLO26n](https://platform.ultralytics.com/ultralytics/yolo26/yolo26n) | 640                         | 2.41                     | 2.68                   |
-| [YOLO26s](https://platform.ultralytics.com/ultralytics/yolo26/yolo26s) | 640                         | 9.50                     | 10.34                  |
-| [YOLO26m](https://platform.ultralytics.com/ultralytics/yolo26/yolo26m) | 640                         | 20.41                    | 34.09                  |
-| [YOLO26l](https://platform.ultralytics.com/ultralytics/yolo26/yolo26l) | 640                         | 24.81                    | 43.21                  |
-| [YOLO26x](https://platform.ultralytics.com/ultralytics/yolo26/yolo26x) | 640                         | 55.73                    | 96.93                  |
+| [YOLOv8n](https://platform.ultralytics.com/ultralytics/yolov8/yolov8n) | 640                         | 3.15                     | 4.39                   |
+| [YOLOv8s](https://platform.ultralytics.com/ultralytics/yolov8/yolov8s) | 640                         | 11.16                    | 14.33                  |
+| [YOLOv8m](https://platform.ultralytics.com/ultralytics/yolov8/yolov8m) | 640                         | 25.89                    | 39.52                  |
+| [YOLOv8l](https://platform.ultralytics.com/ultralytics/yolov8/yolov8l) | 640                         | 43.67                    | 82.65                  |
+| [YOLOv8x](https://platform.ultralytics.com/ultralytics/yolov8/yolov8x) | 640                         | 68.20                    | 128.99                 |
+| [YOLO11n](https://platform.ultralytics.com/ultralytics/yolo11/yolo11n) | 640                         | 2.62                     | 3.26                   |
+| [YOLO11s](https://platform.ultralytics.com/ultralytics/yolo11/yolo11s) | 640                         | 9.44                     | 10.76                  |
+| [YOLO11m](https://platform.ultralytics.com/ultralytics/yolo11/yolo11m) | 640                         | 20.09                    | 34.06                  |
+| [YOLO11l](https://platform.ultralytics.com/ultralytics/yolo11/yolo11l) | 640                         | 25.34                    | 43.54                  |
+| [YOLO11x](https://platform.ultralytics.com/ultralytics/yolo11/yolo11x) | 640                         | 56.92                    | 97.58                  |
+| [YOLO26n](https://platform.ultralytics.com/ultralytics/yolo26/yolo26n) | 640                         | 2.41                     | 2.69                   |
+| [YOLO26s](https://platform.ultralytics.com/ultralytics/yolo26/yolo26s) | 640                         | 9.50                     | 10.38                  |
+| [YOLO26m](https://platform.ultralytics.com/ultralytics/yolo26/yolo26m) | 640                         | 20.41                    | 34.16                  |
+| [YOLO26l](https://platform.ultralytics.com/ultralytics/yolo26/yolo26l) | 640                         | 24.81                    | 43.30                  |
+| [YOLO26x](https://platform.ultralytics.com/ultralytics/yolo26/yolo26x) | 640                         | 55.73                    | 97.06                  |
 
 ## 🤝 Contribute
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,21 +99,21 @@ print(f"Formatted MACs: {macs_readable}, Formatted Parameters: {params_readable}
 
 | 模型                                                                   | 尺寸<br><sup>(像素)</sup> | 参数<br><sup>(百万)</sup> | MACs<br><sup>(十亿)</sup> |
 | ---------------------------------------------------------------------- | ------------------------- | ------------------------- | ------------------------- |
-| [YOLOv8n](https://platform.ultralytics.com/ultralytics/yolov8/yolov8n) | 640                       | 3.15                      | 4.37                      |
-| [YOLOv8s](https://platform.ultralytics.com/ultralytics/yolov8/yolov8s) | 640                       | 11.16                     | 14.30                     |
-| [YOLOv8m](https://platform.ultralytics.com/ultralytics/yolov8/yolov8m) | 640                       | 25.89                     | 39.47                     |
-| [YOLOv8l](https://platform.ultralytics.com/ultralytics/yolov8/yolov8l) | 640                       | 43.67                     | 82.57                     |
-| [YOLOv8x](https://platform.ultralytics.com/ultralytics/yolov8/yolov8x) | 640                       | 68.20                     | 128.90                    |
-| [YOLO11n](https://platform.ultralytics.com/ultralytics/yolo11/yolo11n) | 640                       | 2.62                      | 3.24                      |
-| [YOLO11s](https://platform.ultralytics.com/ultralytics/yolo11/yolo11s) | 640                       | 9.44                      | 10.73                     |
-| [YOLO11m](https://platform.ultralytics.com/ultralytics/yolo11/yolo11m) | 640                       | 20.09                     | 33.99                     |
-| [YOLO11l](https://platform.ultralytics.com/ultralytics/yolo11/yolo11l) | 640                       | 25.34                     | 43.46                     |
-| [YOLO11x](https://platform.ultralytics.com/ultralytics/yolo11/yolo11x) | 640                       | 56.92                     | 97.45                     |
-| [YOLO26n](https://platform.ultralytics.com/ultralytics/yolo26/yolo26n) | 640                       | 2.41                      | 2.68                      |
-| [YOLO26s](https://platform.ultralytics.com/ultralytics/yolo26/yolo26s) | 640                       | 9.50                      | 10.34                     |
-| [YOLO26m](https://platform.ultralytics.com/ultralytics/yolo26/yolo26m) | 640                       | 20.41                     | 34.09                     |
-| [YOLO26l](https://platform.ultralytics.com/ultralytics/yolo26/yolo26l) | 640                       | 24.81                     | 43.21                     |
-| [YOLO26x](https://platform.ultralytics.com/ultralytics/yolo26/yolo26x) | 640                       | 55.73                     | 96.93                     |
+| [YOLOv8n](https://platform.ultralytics.com/ultralytics/yolov8/yolov8n) | 640                       | 3.15                      | 4.39                      |
+| [YOLOv8s](https://platform.ultralytics.com/ultralytics/yolov8/yolov8s) | 640                       | 11.16                     | 14.33                     |
+| [YOLOv8m](https://platform.ultralytics.com/ultralytics/yolov8/yolov8m) | 640                       | 25.89                     | 39.52                     |
+| [YOLOv8l](https://platform.ultralytics.com/ultralytics/yolov8/yolov8l) | 640                       | 43.67                     | 82.65                     |
+| [YOLOv8x](https://platform.ultralytics.com/ultralytics/yolov8/yolov8x) | 640                       | 68.20                     | 128.99                    |
+| [YOLO11n](https://platform.ultralytics.com/ultralytics/yolo11/yolo11n) | 640                       | 2.62                      | 3.26                      |
+| [YOLO11s](https://platform.ultralytics.com/ultralytics/yolo11/yolo11s) | 640                       | 9.44                      | 10.76                     |
+| [YOLO11m](https://platform.ultralytics.com/ultralytics/yolo11/yolo11m) | 640                       | 20.09                     | 34.06                     |
+| [YOLO11l](https://platform.ultralytics.com/ultralytics/yolo11/yolo11l) | 640                       | 25.34                     | 43.54                     |
+| [YOLO11x](https://platform.ultralytics.com/ultralytics/yolo11/yolo11x) | 640                       | 56.92                     | 97.58                     |
+| [YOLO26n](https://platform.ultralytics.com/ultralytics/yolo26/yolo26n) | 640                       | 2.41                      | 2.69                      |
+| [YOLO26s](https://platform.ultralytics.com/ultralytics/yolo26/yolo26s) | 640                       | 9.50                      | 10.38                     |
+| [YOLO26m](https://platform.ultralytics.com/ultralytics/yolo26/yolo26m) | 640                       | 20.41                     | 34.16                     |
+| [YOLO26l](https://platform.ultralytics.com/ultralytics/yolo26/yolo26l) | 640                       | 24.81                     | 43.30                     |
+| [YOLO26x](https://platform.ultralytics.com/ultralytics/yolo26/yolo26x) | 640                       | 55.73                     | 97.06                     |
 
 ## 🤝 贡献
 

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -18,6 +18,7 @@ from thop.vision.basic_hooks import (
     count_convNd,
     count_convtNd,
     count_embedding,
+    count_gated_activation,
     count_linear,
     count_multihead_attention,
     count_normalization,
@@ -66,6 +67,24 @@ register_hooks = {
     nn.ReLU: zero_ops,
     nn.ReLU6: zero_ops,
     nn.LeakyReLU: zero_ops,
+    # the rest of torch.nn's stateless activations that, like LeakyReLU's own negative_slope * x, only ever multiply
+    # by a fixed, data-independent scalar (alpha/beta/lambda) or do no multiply at all (compare/select/exp/log) —
+    # SiLU/GELU below are the two that gate by a genuine per-element function of the input instead.
+    nn.ELU: zero_ops,
+    nn.CELU: zero_ops,
+    nn.SELU: zero_ops,
+    nn.Sigmoid: zero_ops,
+    nn.LogSigmoid: zero_ops,
+    nn.Tanh: zero_ops,
+    nn.Tanhshrink: zero_ops,
+    nn.Hardtanh: zero_ops,
+    nn.Hardsigmoid: zero_ops,
+    nn.Hardshrink: zero_ops,
+    nn.Softplus: zero_ops,
+    nn.Softshrink: zero_ops,
+    nn.Softsign: zero_ops,
+    nn.RReLU: zero_ops,
+    nn.Threshold: zero_ops,
     nn.MaxPool1d: zero_ops,
     nn.MaxPool2d: zero_ops,
     nn.MaxPool3d: zero_ops,
@@ -99,11 +118,7 @@ register_hooks = {
     nn.ParameterList: zero_ops,
     nn.ParameterDict: zero_ops,
     # layers that only move elements around: a view, a re-index or a permutation reads and writes each
-    # element once and multiplies nothing. The elementwise activations that also reach no rule are left
-    # warned about on purpose, because registering one asserts it is free and SiLU, Mish, GELU, GLU and
-    # Hardswish each multiply per element, so they want formulas rather than a blanket entry. nn.Fold is
-    # out because it sums OVERLAPPING blocks, and an addition per input over a window is the work
-    # count_adap_avgpool charges rather than something a view does.
+    # element once and multiplies nothing.
     nn.Identity: zero_ops,
     nn.Flatten: zero_ops,
     nn.Unflatten: zero_ops,
@@ -111,6 +126,16 @@ register_hooks = {
     nn.PixelShuffle: zero_ops,
     nn.PixelUnshuffle: zero_ops,
     nn.ChannelShuffle: zero_ops,
+    # SiLU/GELU gate the input by a non-multiplying function of itself (x * sigmoid(x), x * Phi(x)): one real
+    # multiply per output element, the same accounting convention count_linear already uses for its own folded-in
+    # adds (README: "counting Multiply-Accumulate Operations") — as opposed to a window/reduction rule like
+    # count_avgpool or count_softmax, which charges every scalar op including adds and divides. Mish and GLU have
+    # the identical x * g(x) shape and Hardswish's tail is the same class of work, but none of the three has a
+    # consumer in ultralytics/nn/ to motivate carrying a formula, so they stay unregistered and warned about — same
+    # as nn.Fold, which sums OVERLAPPING blocks (the window-reduction work count_adap_avgpool charges, not
+    # something a view does) and has no consumer either.
+    nn.SiLU: count_gated_activation,
+    nn.GELU: count_gated_activation,
     # a gather, so it belongs with the block above, but max_norm keeps it out of a blanket zero: that rescale is
     # real work and count_embedding warns rather than assert it away, the way count_upsample does for a mode it has
     # no cost for. nn.EmbeddingBag stays unregistered, since it really does reduce each bag and how many adds that

--- a/thop/profile.py
+++ b/thop/profile.py
@@ -67,9 +67,7 @@ register_hooks = {
     nn.ReLU: zero_ops,
     nn.ReLU6: zero_ops,
     nn.LeakyReLU: zero_ops,
-    # the rest of torch.nn's stateless activations that, like LeakyReLU's own negative_slope * x, only ever multiply
-    # by a fixed, data-independent scalar (alpha/beta/lambda) or do no multiply at all (compare/select/exp/log) —
-    # SiLU/GELU below are the two that gate by a genuine per-element function of the input instead.
+    # LeakyReLU-shaped: a fixed-scalar multiply or none at all. SiLU/GELU below gate by a function of x instead.
     nn.ELU: zero_ops,
     nn.CELU: zero_ops,
     nn.SELU: zero_ops,
@@ -126,14 +124,8 @@ register_hooks = {
     nn.PixelShuffle: zero_ops,
     nn.PixelUnshuffle: zero_ops,
     nn.ChannelShuffle: zero_ops,
-    # SiLU/GELU gate the input by a non-multiplying function of itself (x * sigmoid(x), x * Phi(x)): one real
-    # multiply per output element, the same accounting convention count_linear already uses for its own folded-in
-    # adds (README: "counting Multiply-Accumulate Operations") — as opposed to a window/reduction rule like
-    # count_avgpool or count_softmax, which charges every scalar op including adds and divides. Mish and GLU have
-    # the identical x * g(x) shape and Hardswish's tail is the same class of work, but none of the three has a
-    # consumer in ultralytics/nn/ to motivate carrying a formula, so they stay unregistered and warned about — same
-    # as nn.Fold, which sums OVERLAPPING blocks (the window-reduction work count_adap_avgpool charges, not
-    # something a view does) and has no consumer either.
+    # x * g(x) gate: one multiply per output element. Mish/GLU/Hardswish (same shape) and nn.Fold have no consumer
+    # in ultralytics/nn/, so they stay unregistered and warned about.
     nn.SiLU: count_gated_activation,
     nn.GELU: count_gated_activation,
     # a gather, so it belongs with the block above, but max_norm keeps it out of a blanket zero: that rescale is

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -95,6 +95,16 @@ def count_prelu(m, x, y):
         m.total_ops += x.numel()
 
 
+def count_gated_activation(m, x, y):
+    """Count the data-multiplies in a self-gated activation (SiLU/GELU: x * g(x)); the gate's own compare/exp/log tail
+    contributes no multiply, the same convention count_linear already applies to its folded-in adds.
+
+    GELU's tanh approximation cubes x inside the gate (x + 0.044715 * x**3), two more data multiplies on top of the
+    outer x * gate one; GELU's exact form and SiLU have only the outer one.
+    """
+    m.total_ops += y.numel() * (3 if getattr(m, "approximate", "none") == "tanh" else 1)
+
+
 def count_softmax(m, x, y):
     """Calculate and update the total operation counts for a Softmax layer in a PyTorch model."""
     x = x[0]

--- a/thop/vision/basic_hooks.py
+++ b/thop/vision/basic_hooks.py
@@ -96,12 +96,7 @@ def count_prelu(m, x, y):
 
 
 def count_gated_activation(m, x, y):
-    """Count the data-multiplies in a self-gated activation (SiLU/GELU: x * g(x)); the gate's own compare/exp/log tail
-    contributes no multiply, the same convention count_linear already applies to its folded-in adds.
-
-    GELU's tanh approximation cubes x inside the gate (x + 0.044715 * x**3), two more data multiplies on top of the
-    outer x * gate one; GELU's exact form and SiLU have only the outer one.
-    """
+    """Count a self-gated activation's data-multiplies: one for SiLU/GELU, three for GELU's tanh approximation."""
     m.total_ops += y.numel() * (3 if getattr(m, "approximate", "none") == "tanh" else 1)
 
 


### PR DESCRIPTION
## summary

registers silu and gelu with a rule that counts their per-element gate multiply (gelu's tanh approximation counts three, since it cubes the input inside the gate before the outer multiply), and registers the other stateless activations that have no data-multiply in their own formula — only a compare, a select, or a multiply by a fixed hyperparameter scalar — as zero-cost, matching the existing leakyrelu decision. mish, glu and hardswish have the identical genuine-multiply shape but no consumer in ultralytics/nn/ to motivate carrying a formula, and nn.fold's overlap-count formula is nontrivial for the same reason, so all four stay unregistered and warned about rather than getting a formula nobody calls.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📈 Updates THOP activation profiling and refreshes YOLO model MACs benchmarks for more accurate computation estimates.

### 📊 Key Changes
- Added operation counting for `nn.SiLU` and `nn.GELU`, including special handling for GELU’s tanh approximation.
- Registered several additional activations—including ELU, SELU, Sigmoid, Tanh, Softplus, and related layers—as zero-operation layers.
- Updated English and Chinese README benchmark tables with recalculated MAC values for YOLOv8, YOLO11, and YOLO26 models.
- Kept unsupported computational layers such as Mish, GLU, and Hardswish unregistered so THOP continues to warn users rather than report potentially inaccurate estimates.

### 🎯 Purpose & Impact
- ✅ Produces more realistic profiling results for models that use SiLU or GELU activations.
- 📊 Aligns documented YOLO benchmark values with the updated counting behavior.
- 🚀 Helps developers make better-informed decisions about model complexity, performance, and deployment resources.
- 🌍 Keeps profiling documentation consistent across English and Chinese users.