### PR TITLE
Correct inaccurate AGENTS.md claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ After opening a PR:
 # Install in editable mode (deps: numpy, torch)
 uv pip install -e .
 
-# Test deps (tests need pytest; benchmark scripts also need torchvision)
+# Test deps (tests need pytest; the README examples need torchvision;
+# benchmark/evaluate_famous_models.py hard-requires ultralytics==8.4.106)
 uv pip install pytest torchvision
 
 # Run all tests
@@ -56,7 +57,7 @@ npx prettier --write --print-width 120 "**/*.{yml,yaml,json,md}"
 
 ## Architecture
 
-THOP (PyPI package `ultralytics-thop`, import name `thop`) computes MACs of PyTorch models via forward hooks, and parameter counts from the module tree. `thop/profile.py` holds the `register_hooks` dict mapping `nn.Module` types to counting functions and exposes the two entry points: `profile()` (DFS traversal that counts each leaf module once) and the legacy `profile_origin()`. Counting functions live in `thop/vision/basic_hooks.py` (formulas in `thop/vision/calc_func.py`) and `thop/rnn_hooks.py` for RNN/GRU/LSTM; `thop/utils.py` provides `clever_format`. `benchmark/` scripts regenerate the README results table.
+THOP (PyPI package `ultralytics-thop`, import name `thop`) computes MACs of PyTorch models via forward hooks, and parameter counts from the module tree. `thop/profile.py` holds the `register_hooks` dict mapping `nn.Module` types to counting functions and exposes the two entry points: `profile()` (hooks every module via `model.apply(add_hooks)` and sums each hooked module's `total_ops` once — `dfs_count` runs only to build the per-layer tree when `ret_layer_info=True`) and the legacy `profile_origin()` (which does skip non-leaf modules that carry no rule of their own). Counting functions live in `thop/vision/basic_hooks.py` (formulas in `thop/vision/calc_func.py`) and `thop/rnn_hooks.py` for RNN/GRU/LSTM; `thop/utils.py` provides `clever_format`. `benchmark/` scripts regenerate the README results table.
 
 `profile()` accumulates into a plain `total_ops` int written straight into each module's `__dict__` (`profile_origin()` still uses a float64 `register_buffer`), so a rule adds into `m.total_ops` — a plain number is cheapest, and a one-element tensor works too because the traversal reduces it with `float()`. Parameter counts are not hooked: both entry points read them from `nn.Module.parameters()`, which deduplicates shared weights and covers module types that have no counting rule. With `ret_layer_info=True` each node reports the parameters its own subtree holds, deduplicated within that node but not across nodes.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-# Publish pip package to PyPI https://pypi.org/project/ultralytics/ and Docs to https://docs.ultralytics.com
+# Publish pip package to PyPI https://pypi.org/project/ultralytics-thop/
 
 # Overview:
 # This `pyproject.toml` file manages the build, packaging, and distribution of the `thop` library. 


### PR DESCRIPTION
Follow-up to #175. Three statements did not match the source.

- AGENTS.md Commands said the benchmark scripts need torchvision. Neither does: `benchmark/evaluate_rnn_models.py` imports only torch, and `benchmark/evaluate_famous_models.py` imports `ultralytics` and hard-raises unless `__version__ == "8.4.106"`. torchvision is what the README examples need (resnet50). Corrected the comment; the install line is unchanged.
- AGENTS.md Architecture described `profile()` as a "DFS traversal that counts each leaf module once". It is neither DFS nor leaf-restricted: `model.apply(add_hooks)` hooks every module and the total is a flat `sum(...)` over `handler_collection` (`thop/profile.py:371`), so a rule-carrying parent is counted alongside its children. `dfs_count` runs only to build `ret_dict` when `ret_layer_info=True` (`thop/profile.py:372`). Leaf-skipping describes `profile_origin()`, whose `add_hooks` returns early for `list(m.children()) and not has_own_rule` (`thop/profile.py:251`).
- pyproject.toml header pointed at `pypi.org/project/ultralytics/` and claimed the project publishes docs. This project publishes `ultralytics-thop` (as its own publish.yml already states) and publishes no docs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Clarifies THOP’s profiling architecture and updates package publishing documentation.

### 📊 Key Changes

- Updated `AGENTS.md` to clarify:
  - Required dependencies for tests, README examples, and benchmark scripts.
  - How `profile()` hooks modules and accumulates operation counts.
  - Differences between `profile()` and the legacy `profile_origin()`.
  - Parameter-counting behavior, including shared weights and layer-level reporting.
- Corrected the `pyproject.toml` publishing comment to link to the [`ultralytics-thop` PyPI package](https://pypi.org/project/ultralytics-thop/).

### 🎯 Purpose & Impact

- 📚 Makes the project’s development and profiling documentation more accurate and easier to follow.
- 🧪 Helps contributors install the right dependencies for tests and benchmarks.
- 🔍 Improves understanding of operation and parameter-counting behavior, reducing confusion when extending or debugging THOP.
- 📦 Ensures package metadata documentation points to the correct distribution page.